### PR TITLE
docs: update security center and support links to refold domain

### DIFF
--- a/deployment/hosting/intro.mdx
+++ b/deployment/hosting/intro.mdx
@@ -4,7 +4,7 @@ description: "Choose a hosting option that best fit for your needs"
 ---
 
 <Info>
-Cobalt is certified in GDPR, ISO 27001:2022, and SOC 2 Type 2, adhering to the policies and procedures mandated by these standards. Our cloud and managed on-premise solutions fully comply with the requirements of these certifications. For more information, visit our [Security Center](https://security.gocobalt.io/).
+Cobalt is certified in GDPR, ISO 27001:2022, and SOC 2 Type 2, adhering to the policies and procedures mandated by these standards. Our cloud and managed on-premise solutions fully comply with the requirements of these certifications. For more information, visit our [Security Center](https://security.refold.ai/).
 </Info>
 
 ## Overview

--- a/deployment/overview.mdx
+++ b/deployment/overview.mdx
@@ -14,7 +14,7 @@ Each hosting option is optimized for performance, security, and scalability, cat
 
 ## Solutions We Offer
 
-Cobalt is **GDPR**, **ISO 27001 v2022**, **SOC2 Type 2 certified**, and both our cloud and managed on-premise solutions adhere to the policies and procedures required in the certification. [Details here](https://security.gocobalt.io/). 
+Cobalt is **GDPR**, **ISO 27001 v2022**, **SOC2 Type 2 certified**, and both our cloud and managed on-premise solutions adhere to the policies and procedures required in the certification. [Details here](https://security.refold.ai/). 
 
 We offer several solutions to fit your needs:  
 

--- a/governance/application-security.mdx
+++ b/governance/application-security.mdx
@@ -32,8 +32,8 @@ All employees undergo regular security training to stay updated on the latest th
 
 ## Reporting & Transparency
 
-Customers can request a copy of our security reports through our dedicated [Security Center](https://security.gocobalt.io/) or by emailing us at **support@gocobalt.io**.
+Customers can request a copy of our security reports through our dedicated [Security Center](https://security.refold.ai/) or by emailing us at **support@refold.ai**.
 
 ## Contact Us
 
-If you have any security-related questions or concerns, please contact our security team at **support@gocobalt.io**.
+If you have any security-related questions or concerns, please contact our security team at **support@refold.ai**.

--- a/governance/certifications.mdx
+++ b/governance/certifications.mdx
@@ -16,5 +16,5 @@ Cobalt undergoes regular security audits and adheres to leading industry standar
 This comprehensive security framework underscores the commitment to delivering secure and reliable services while continually enhancing processes to protect the business, partners, and their data.
 
 <Info>
-Customers can request a copy of our reports through our dedicated [Security Center](https://security.gocobalt.io/) or by emailing us at **support@gocobalt.io**.
+Customers can request a copy of our reports through our dedicated [Security Center](https://security.refold.ai/) or by emailing us at **support@refold.ai**.
 </Info>

--- a/governance/overview.mdx
+++ b/governance/overview.mdx
@@ -10,7 +10,7 @@ At **Cobalt**, we prioritize the **confidentiality**, **integrity**, and **avail
 As a trusted **service provider and product company**, we understand the need to deliver transparent and detailed insights into our **security practices**, **tools**, **resources**, and **responsibilities**. This ensures our customers feel confident in selecting us as their reliable provider.
 
 <Info>
-We undergo regular annual audits and collaborate with a third-party monitoring system to ensure continuous compliance. Customers can request a copy of our reports through our dedicated [Security Center](https://security.gocobalt.io/resources).
+We undergo regular annual audits and collaborate with a third-party monitoring system to ensure continuous compliance. Customers can request a copy of our reports through our dedicated [Security Center](https://security.refold.ai/resources).
 </Info>
 
 ## Key Highlights of Our Security
@@ -28,4 +28,4 @@ We are dedicated to maintaining a robust and proactive approach to safeguarding 
 - [Contact Our Team](https://www.gocobalt.io/contact-us)
 - [Terms of Service](https://www.gocobalt.io/terms-of-use)  
 - [Privacy Policy](https://www.gocobalt.io/privacy-policy)
-- [Security Center](https://security.gocobalt.io)
+- [Security Center](https://security.refold.ai)


### PR DESCRIPTION
Replace security.gocobalt.io with security.refold.ai and support@gocobalt.io with support@refold.ai across deployment and governance docs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Security Center URL to `security.refold.ai` across compliance and security documentation
  * Changed support email contact to `support@refold.ai` for security-related inquiries

<!-- end of auto-generated comment: release notes by coderabbit.ai -->