### PR TITLE
docs: rebrand root and landing pages from Cobalt to Refold

### DIFF
--- a/glossary.mdx
+++ b/glossary.mdx
@@ -1,17 +1,17 @@
 ---
 title: Glossary
-description: "This page describes common terms used in the Cobalt interface and documentation."
+description: "This page describes common terms used in the Refold interface and documentation."
 ---
 
-**Linked account**: Your end-customer is called a linked account. You can check the list of added linked accounts on Cobalt's dashboard
+**Linked account**: Your end-customer is called a linked account. You can check the list of added linked accounts on Refold's dashboard
 
 **Linked account id**: Each linked account has its own unique id that needs to be passed in the backend SDK
 
 **session_token**: Session token a temporary token that is used to initialize the frontend SDK. Session token is generated from getTokenForLinkedAccount() function of the backend SDK
 
-**Events**: Events happen on your platform and you trigger the Cobalt's events API with a pre-defined payload. You can create and update the events on Cobalt's dashboard.
+**Events**: Events happen on your platform and you trigger the Refold's events API with a pre-defined payload. You can create and update the events on Refold's dashboard.
 
-**Actions**: Actions are your API end points on which Cobalt will send the data back. You can define the authorization method, list of parameters that your API will expect etc. on Cobalt's dashboard
+**Actions**: Actions are your API end points on which Refold will send the data back. You can define the authorization method, list of parameters that your API will expect etc. on Refold's dashboard
 
 **auth_credentials**: While creating a linked account using the createLinkedAccount() function, you can also pass auth_credentials of your end-customer. This will be later used while setting up 'Actions' and sending authorized requests on your end-points.
 

--- a/introduction.mdx
+++ b/introduction.mdx
@@ -1,9 +1,9 @@
 ---
 title: Introduction
 ---
-Welcome to Cobalt! Cobalt is a dev tool to enable SaaS companies add 3rd party native integration. 
+Welcome to Refold! Refold is a dev tool to enable SaaS companies add 3rd party native integration. 
 This allows teams to avoid the cost, time, and risk that comes with building and maintaining their own integrations solution. 
-A single installation of Cobalt takes just a couple hours and enables your application to support integrations with the most popular SaaS apps.
+A single installation of Refold takes just a couple hours and enables your application to support integrations with the most popular SaaS apps.
 
 <img
   src="/images/intro.png"
@@ -31,19 +31,19 @@ The first step to world-class documentation is setting up your editing environnm
   <Card
     title="Examples"
     icon="book"
-    href="https://docs.gocobalt.io/implementation/examples/"
+    href="https://docs.refold.ai/implementation/examples/"
   >
-    Build your first integration with Cobalt by following these guides.
+    Build your first integration with Refold by following these guides.
   </Card>
 </CardGroup>
 
 ## Explore
 
-Guides to commonly used Cobalt features to make the most of our platform.
+Guides to commonly used Refold features to make the most of our platform.
 
 <CardGroup cols={3}>
   <Card
-    title="Cobalt Basics"
+    title="Refold Basics"
     icon="palette"
     href="/build/basics"
   >
@@ -68,7 +68,7 @@ Guides to commonly used Cobalt features to make the most of our platform.
     icon="flag"
     href="/build/basics/webhooks"
   >
-    Learn about the Cobalt Webhook events
+    Learn about the Refold Webhook events
   </Card>
 </CardGroup>
 

--- a/mint.json
+++ b/mint.json
@@ -31,7 +31,7 @@
   ],
   "topbarCtaButton": {
     "name": "Dashboard",
-    "url": "https://app.gocobalt.io/"
+    "url": "https://app.refold.ai/"
   },
   "tabs": [
     {
@@ -75,7 +75,7 @@
     {
       "name": "Get Your API Key",
       "icon": "gear",
-      "url": "https://app.gocobalt.io/developer"
+      "url": "https://app.refold.ai/developer"
     },
     {
       "name": "Examples",
@@ -494,7 +494,7 @@
         ]
         },
         {
-          "group": "Cobalt Hosted",
+          "group": "Refold Hosted",
           "pages": [
             "api-reference/cobalt-connect/get-connect-url",
             "api-reference/cobalt-connect/get-hosted-properties"
@@ -597,7 +597,7 @@
       ]
     },
     {
-      "group": "Cobalt SDKs",
+      "group": "Refold SDKs",
       "pages": [
             "sdks/overview"
         ]

--- a/overview.mdx
+++ b/overview.mdx
@@ -1,9 +1,9 @@
 ---
 title: Introduction
 ---
-Welcome to Cobalt! Cobalt is a dev tool to enable SaaS companies add 3rd party native integration. 
+Welcome to Refold! Refold is a dev tool to enable SaaS companies add 3rd party native integration. 
 This allows teams to avoid the cost, time, and risk that comes with building and maintaining their own integrations solution. 
-A single installation of Cobalt takes just a couple hours and enables your application to support integrations with the most popular SaaS apps.
+A single installation of Refold takes just a couple hours and enables your application to support integrations with the most popular SaaS apps.
 
 <img
   src="/images/intro.png"
@@ -31,19 +31,19 @@ The first step to world-class documentation is setting up your editing environnm
   <Card
     title="Examples"
     icon="book"
-    href="https://docs.gocobalt.io/implementation/examples/"
+    href="https://docs.refold.ai/implementation/examples/"
   >
-    Build your first integration with Cobalt by following these guides.
+    Build your first integration with Refold by following these guides.
   </Card>
 </CardGroup>
 
 ## Explore
 
-Guides to commonly used Cobalt features to make the most of our platform.
+Guides to commonly used Refold features to make the most of our platform.
 
 <CardGroup cols={3}>
   <Card
-    title="Cobalt Basics"
+    title="Refold Basics"
     icon="palette"
     href="/build/basics"
   >
@@ -68,7 +68,7 @@ Guides to commonly used Cobalt features to make the most of our platform.
     icon="flag"
     href="/build/basics/webhooks"
   >
-    Learn about the Cobalt Webhook events
+    Learn about the Refold Webhook events
   </Card>
 </CardGroup>
 

--- a/quickstart.mdx
+++ b/quickstart.mdx
@@ -1,13 +1,13 @@
 ---
 title: 'Quickstart'
-description: 'This guide will help you understand how you could try out Cobalt platform and the demo workflows.'
+description: 'This guide will help you understand how you could try out Refold platform and the demo workflows.'
 ---
 This guide covers the key steps, including configuring credentials, setting up a workflow, and testing the workflows. Follow the steps given below to execute a demo workflow present in your account and get the response.
 
 ## Step 1: Configure Your Integration Credentials
 The first step is to configure your credentials for the integration you want to test if required.
 
-Cobalt supports 2 types of Authentication: **Key-based** and **OAuth 2.0** which you can check by navigating to your integration in `Apps` > `Settings` of the integration.
+Refold supports 2 types of Authentication: **Key-based** and **OAuth 2.0** which you can check by navigating to your integration in `Apps` > `Settings` of the integration.
 <AccordionGroup>
   <Accordion title="For Key-Based">
 
@@ -45,7 +45,7 @@ Once your credentials are configured, you can also check the demo workflows alre
 In most integrations where you want to fetch some data, you'll need to setup API proxy to capture workflow's final response during testing. It's not necessary that every workflow will have an API Proxy present, in that case you can skip this step.
 
 <Tip>
-Learn more about API Proxy [here](https://docs.gocobalt.io/build/basics/proxies).
+Learn more about API Proxy [here](https://docs.refold.ai/build/basics/proxies).
 </Tip>
 
 Follow the steps given below to setup your own URL where you can receive the response: 
@@ -55,16 +55,16 @@ Follow the steps given below to setup your own URL where you can receive the res
 
 For eg: In the image above, the name of the API Proxy or Action present is **Bulk Create Contacts**.
 - To get your own URL for setup, go to [webhook.site](https://webhook.site/) and copy `Your unique URL`. 
-- In Cobalt, navigate to `Developers` > `API Proxies` > Search for the Action name that was setup in the workflow > Select it and paste the unique URL you copied under `Request URL` present in `API Call` and click on `Save API Call`.
+- In Refold, navigate to `Developers` > `API Proxies` > Search for the Action name that was setup in the workflow > Select it and paste the unique URL you copied under `Request URL` present in `API Call` and click on `Save API Call`.
 <img height="200" src="/images/Concepts/proxy_url.png" alt="Settings up API URL in API Proxy"/>
 
 ## Step 4: Authenticate Linked Account
 
 Next step is to perform authentication of a Linked Account to the integration, to link it to the workflow.
 
-[Linked Accounts](https://docs.gocobalt.io/build/basics/linked_account) refers to the end-users or customers of our users who utilize the integrations built using the Cobalt platform.
+[Linked Accounts](https://docs.refold.ai/build/basics/linked_account) refers to the end-users or customers of our users who utilize the integrations built using the Refold platform.
 
-Go to `Linked Accounts` section in Cobalt and open any Linked Account present.
+Go to `Linked Accounts` section in Refold and open any Linked Account present.
 <Note>
 You can also create a new linked account if you want by clicking on `+ Add Account` button in the top right.
 </Note>
@@ -72,9 +72,9 @@ You can also create a new linked account if you want by clicking on `+ Add Accou
 Click on `Get Hosted URL` button > `Generate Hosted URL` > Copy the URL shown and open it in a new tab.
 <img height="200" src="/images/Concepts/hosted.png" alt="Navigate to Hosted Portal"/>
 
-Hosted Portal is a no-code solution built by Cobalt so that you don’t need to build your own UI to handle the integration authentication and configuration which we will now use for testing purposes.
+Hosted Portal is a no-code solution built by Refold so that you don’t need to build your own UI to handle the integration authentication and configuration which we will now use for testing purposes.
 <Info>
-You can also build your own UI for end-users using our SDKs or APIs and [Auth Flows](https://docs.gocobalt.io/ship/auth_flows/flows).
+You can also build your own UI for end-users using our SDKs or APIs and [Auth Flows](https://docs.refold.ai/ship/auth_flows/flows).
 </Info>
 
 In the Hosted portal, navigate to the integration for which you want to perform authentication. If it's **OAuth** simply click on `Connect` or provide credentials if it's **Key-based** and click on `Connect`. If the authentication is successful you should see a **Connected** tag displayed beside the integration name.
@@ -90,12 +90,12 @@ Now that everything is set up, you can proceed to test the workflow.
 
 Trigger of a Workflow can either be:
 1. **Native App Trigger** which triggers when a certain action is performed in the application. For eg: If the `Contact Created` trigger of HubSpot is present in the **Start Node** of your workflow, then it triggers when a new contact is added to your HubSpot account.
-2. **Event based triggers** which triggers when an event is called on Cobalt. You can check which Event is added to the workflow by checking the **Start Node** of the workflow.
+2. **Event based triggers** which triggers when an event is called on Refold. You can check which Event is added to the workflow by checking the **Start Node** of the workflow.
 
-    - To start the workflow execution, go to [**Try API**](https://docs.gocobalt.io/ship/tryapi) section in Cobalt, provide the required details and click on `Fire Event`.
-    <img height="200" src="/images/Guides/Platform/try-api.png" alt="Try API Section in Cobalt"/>
+    - To start the workflow execution, go to [**Try API**](https://docs.refold.ai/ship/tryapi) section in Refold, provide the required details and click on `Fire Event`.
+    <img height="200" src="/images/Guides/Platform/try-api.png" alt="Try API Section in Refold"/>
 
-Once the Event is fired, you can see the Event and Execution logs of your workflow by navigating to [**Logs**](https://docs.gocobalt.io/maintain/logs) section.
+Once the Event is fired, you can see the Event and Execution logs of your workflow by navigating to [**Logs**](https://docs.refold.ai/maintain/logs) section.
 
 Also, if the workflow executed successfully, you can check the final response received on your [webhook.site](https://webhook.site/).
 
@@ -104,5 +104,5 @@ Hurray! You have successfully completed setup for an integration and also execut
 </Check>
 
 
-## Go Deeper and Explore Cobalt
-This was a simple overview to setup native integrations using Cobalt, and how Linked Accounts and workflows interact within the platform. You can further customize workflows, explore advanced testing scenarios, or discuss alternative UI implementations on a follow-up call.
+## Go Deeper and Explore Refold
+This was a simple overview to setup native integrations using Refold, and how Linked Accounts and workflows interact within the platform. You can further customize workflows, explore advanced testing scenarios, or discuss alternative UI implementations on a follow-up call.


### PR DESCRIPTION
Update mint.json (dashboard URL, API key anchor, nav group labels), overview, introduction, quickstart, and glossary to use Refold branding and refold.ai cross-links.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Rebranded product references from Cobalt to Refold across all documentation
  * Updated external links and URLs to point to Refold domains
  * Refreshed navigation labels and configuration to reflect new branding
  * Updated examples and related documentation references throughout

<!-- end of auto-generated comment: release notes by coderabbit.ai -->