### PR TITLE
Release notes — v3.5.29 (supersedes v3.5.26, v3.5.27, v3.5.28)

### DIFF
--- a/changelog/2026.mdx
+++ b/changelog/2026.mdx
@@ -98,49 +98,67 @@ rss: true
 
 </Update>
 
-<Update label="May 27, 2026" description="v3.5.29 · Project redesign, Agent Sessions, expanded tables & SAP Ariba SOAP">
+<Update label="May 27, 2026" description="v3.5.29 · Agent Sessions, Project workspace redesign, DLQ, Entity Tags & SAP Ariba SOAP">
 
 <Badge color="blue">Platform</Badge> <Badge color="orange">Agent</Badge> <Badge color="green">APIs</Badge> <Badge color="purple">Integrations</Badge>
 
-**A redesigned project experience with a new sidebar layout, Agent Sessions for managing and resuming AI conversations, tables expanded to 30 columns, JSON Schema on Event triggers, and SAP Ariba SOAP API support.**
+**A redesigned Project workspace with Agent Sessions, a new Dead Letter Queue primitive, Entity Tags for grouping events, expanded SAP Ariba SOAP coverage, JSON schema validation on Event triggers, and a wide set of node and integration fixes.**
 
 **New Features**
 
-- **Project Redesign**: New fullscreen sidebar layout with catalog-style sub-pages for Workflows, Documents, Artifacts, Lookups, Memories, Alerts, Error Reporting, and Settings. The project overview page is now a chat prompt scoped to your project.
-- **Applications Renamed to Integrations**: The Applications sidebar item is now labelled **Integrations** throughout the platform.
-- **Agent Sessions**: Agent sessions are now tracked in the workflow builder and chat surfaces. Recent sessions appear in the sidebar for quick resume, with client-minted session IDs ensuring reliable continuity.
-- **Tables — 30-Column Limit**: The maximum number of columns per persistent table has been raised from 10 to 30.
-- **JSON Schema on Event Triggers**: Event triggers now support a JSON Schema field for payload validation, with both a Payload tab and a JSON Schema tab in the event configuration.
-- **SAP Ariba SOAP API Actions**: New integration module covering purchase-requisition actions via the SAP Ariba SOAP API.
-- **OpenAPI Import — Nested Fields**: Fields nested inside object and array types are now fully expanded when importing an API proxy from an OpenAPI spec, instead of being silently dropped.
-- **JSON-to-CSV Column Ordering**: A new optional `header_order` field on the JSON-to-CSV node lets you specify the exact column order in the generated CSV file.
-- **Terminate with Error Context**: The error context from `terminate_with_error` nodes is now surfaced on the execution details page.
-- **Workflow Version Publisher**: The name of the user who published a workflow version is now shown in the version history.
-- **Linked Account Scope**: Linked accounts can now be created and filtered by a custom `scope` identifier — useful for multi-tenant setups that need to distinguish account groups.
+- **Project Workspace Redesign**: Fullscreen sidebar layout for the project page, with all sub-pages (Workflows, Documents, Artifacts, Lookups, Memories, Alerts, Error Reporting, Settings) rebuilt on a consistent catalog layout. The project Overview is now a project-scoped chat prompt, and `/project/:project` auto-redirects to `/project/:project/overview`.
+- **Applications Renamed to Integrations**: The project sidebar item is now labeled "Integrations" with a catalog-style listing and editorial header.
+- **Agent Sessions**: Sessions are now a platform primitive tracked across the workflow builder and chat surfaces. The Agent sidebar shows the last three sessions for quick resume, in-flight chats can be resumed after reload, and a recent-sessions empty state replaces the previous blank state. Instance analysis is now powered by Agent Sessions as well.
+- **Project-Scoped New Prompt View**: New prompt experience with agent chips, recent sessions, agent context chips, predefined prompts, a floating send button, and a sticky prompt bar.
+- **Infinite Scroll on Project List**: Project list now loads pages lazily as you scroll, with a new search parameter for filtering.
+- **Dead Letter Queue (DLQ)**: New DLQ primitive with full CRUD endpoints and workflow assignment support, providing a place to capture and manage workflows that fail terminally.
+- **Entity Tags**: New org-scoped, environment-specific tags for grouping events. Includes a fixed color palette aligned with the Connect Portal, a limit of 20 tags per environment, and case-only renames preserved. Custom triggers can now be tagged via a new `tag_ids` field.
+- **Linked Account Scope**: Linked accounts now support an optional `scope` field, accepted on create, update, upsert, and CSV upload, and queryable as a filter on list endpoints.
+- **CSV Column Ordering**: The JSON to CSV node now accepts an optional `header_order` field to control the column order in the generated CSV.
+- **CSV Escape Sequences**: The JSON to CSV node now interprets `\n`, `\t`, and `\r` in the `delimiter` and `line_ending` fields as actual control characters.
+- **Inline CSV Raw Data**: When `return_raw_data` is set at the top level, the JSON to CSV lambda now returns CSV data inline.
+- **Python Custom Code Nodes**: Python custom code nodes now execute successfully, routed through a dedicated Python executor.
+- **Version History Publisher**: Workflow versions now record and display the publishing user's name.
+- **Terminate-With-Error Context**: The error context from a Terminate node now surfaces on the execution page.
+- **Inline "Add an Entry Node"**: Cleaner inline layout for adding an entry node to loops and other containers.
+- **Canvas Panning with Side Panels**: Opening the AI window in the workflow builder now switches the canvas to panning mode with panels docked on the right.
+- **MCP Audits Search-Tools Filter**: MCP audit lists now support an `include_search_tools` filter.
 
 **Improvements**
 
-- The canvas automatically switches to panning mode when the AI assistant panel opens, keeping your viewport stable.
-- Copy URL, cURL, and JavaScript actions in the Start node panel now work correctly when the workflow builder is embedded in an iframe.
-- The PDF node now accepts string-typed numbers (e.g., `"1080"`) for viewport height, viewport width, wait time, and TTL fields.
-- The PDF node Margin field now validates JSON and surfaces a clear error for invalid values.
-- Python custom code execution improved.
-- Try-Catch nodes with an empty catch body now immediately transition to an error state with a clear message instead of hanging indefinitely.
+- **JSON Schema Validation on Event Triggers**: Event trigger config now exposes both Payload and JSON Schema tabs, with client-side schema validation on save and field-level errors on mismatched payloads at execution.
+- **OpenAPI Import — Nested Fields**: Importing an API proxy from an OpenAPI spec now recursively expands nested object and array fields as child `properties` on the parent, instead of silently dropping them.
+- **Tables — 30 Column Limit**: The per-table column limit is raised from 10 to 30, and is now configurable via `maxColumnsPerTable`.
+- **Tables — Edit Records**: Existing table records can now be updated via a new `PATCH` endpoint.
+- **PDF Node — Numeric Coercion**: Templated string values like `viewport_height: "1080"` and `wait_after_load: "500"` are now coerced to numbers before validation, so PDFs generate instead of failing.
+- **PDF Node — Margin Validation**: The Margin field is now validated as JSON, throwing a clear error for invalid input instead of silently generating with defaults. The placeholder text now uses single quotes to avoid copy-paste confusion with valid JSON.
+- **Copy URL / cURL / JavaScript in Iframes**: Copy actions on the Start node's API Call panel now work inside embedded iframes, with a graceful fallback and manual-copy instructions when blocked by cross-origin policy.
+- **Empty Try-Catch Blocks**: An empty Try-Catch block now fails fast and transitions to ERRORED with a clear message instead of hanging in RUNNING.
+- **Monaco Template Variables**: Template expressions like `{{node.x.body}}` no longer show as lint errors in Monaco-backed fields.
+- **Code Executor Node Naming**: Resolved a naming inconsistency on the Code Executor node.
+
+**Bug Fixes**
+
+- **Slack Webhook Delivery**: Slack webhook deliveries now succeed.
+- **Salesforce v3 Action Picker**: Salesforce v3 actions are visible in the action picker again.
 
 **API Changes**
 
+- New: Dead Letter Queue CRUD endpoints under `/api/v2/public/` for creating, listing, updating, and deleting DLQ entries and assigning them to workflows.
+- New: `POST`, `GET`, `PATCH`, `DELETE /api/v2/public/tags/*` — manage Entity Tags.
+- New: `PATCH /api/v2/public/tables/:tableId/records/:recordId` — update an existing table record.
+- `POST` and `PATCH /api/v2/public/linked-accounts` — now accept an optional `scope` field.
+- `GET /api/v2/public/linked-accounts` — now supports a `scope` query filter.
 - Event trigger create and update payloads now accept a `json_schema` field for payload validation.
-- Linked Account create, update, and upsert payloads now accept an optional `scope` field; `GET /linked-accounts` now supports `scope` as a query filter.
-- New `PATCH /api/v2/public/tables/:tableId/records/:recordId` endpoint for updating individual table records.
+- Custom trigger schema now accepts a `tag_ids` field for tagging.
 
 **Integration Updates**
 
-- **SAP Ariba SOAP**: New integration with purchase-requisition actions.
-- **Salesforce**: v3 actions restored in the action picker.
-- **HubSpot**: Contact list selection migrated from the deprecated v1 Lists API to v3.
-- **Slack**: Webhook delivery restored.
-- **Zoho**: Action identifier alignment for `get_lead`, `get_task`, and `get_campaign`.
-- **CSV**: `header_order` field for column ordering; delimiter and line-ending fields now correctly interpret escape sequences such as `\n` and `\t`; `return_raw_data` now returns data inline.
+- **SAP Ariba**: New SOAP API actions, prioritizing purchase requisition workflows.
+- **SAP**: Authentication for SAP-backed workflows no longer expires mid-run.
+- **HubSpot**: Migrated the Select Contact List action from the sunset v1 Lists API to the v3 CRM Lists API. The `list_ids` action is restored.
+- **Zoho**: Operation identifiers aligned for `get_lead`, `get_task`, and `get_campaign`.
+- **Snowflake**: Refreshed the query field editor.
 
 </Update>
 


### PR DESCRIPTION
Auto-drafted from the engineering release notes Google Doc by Claude.

**Please review carefully before merging.**

- Verify all customer-facing changes are captured.
- Confirm action-required callouts have correct URLs and instructions.
- Check that no internal context (ticket IDs, customer names, service names, infra metrics) leaked through.
- Confirm doc links resolve.

**This PR supersedes internal-only releases.**

The engineer marked the v3.5.29 tab with `Supersedes: 3.5.26, 3.5.27, 3.5.28`. Content from those tabs (where found) was consolidated into the v3.5.29 draft, and existing blocks for those versions in the published docs were removed.

| Superseded version | Tab consolidated into draft | Block in published docs |
| --- | --- | --- |
| v3.5.26 | Yes — content included | Not found (was never published) |
| v3.5.27 | Yes — content included | Not found (was never published) |
| v3.5.28 | Yes — content included | Not found (was never published) |

If "No tab found" appears for a version you expected to consolidate, check that the doc has a tab whose title contains that exact version number (for example, `Refold: 3.5.27`). The script matches on version tokens in tab titles.

⚠️ If the engineer re-runs the drafter, the `v3.5.29` block in this PR will be regenerated and any manual edits to that block will be overwritten. Edits to other blocks in this file are preserved.