### PR TITLE
Minor fixes: tab active-state visibility + quickstart broken links

### DIFF
--- a/style.css
+++ b/style.css
@@ -118,6 +118,21 @@ h1, h2, h3, h4, h5, h6,
   font-family: var(--rf-font-mono);
   letter-spacing: 0.04em;
 }
+/* Active in-content tab — Mintlify's default indicator is a thin gray underline
+   the same color as the label, so the selected tab is hard to spot. Give it an
+   electric-blue label + underline (lighter blue in dark mode) so the active tab
+   is unmistakable. Matches the top-nav tab treatment. */
+#content-area [role="tab"][aria-selected="true"],
+#content-area [class*="tab"] button[aria-selected="true"] {
+  color: var(--rf-electric-blue) !important;
+  border-bottom: 2px solid var(--rf-electric-blue) !important;
+  font-weight: 600 !important;
+}
+.dark #content-area [role="tab"][aria-selected="true"],
+.dark #content-area [class*="tab"] button[aria-selected="true"] {
+  color: var(--primary-light) !important;
+  border-bottom-color: var(--primary-light) !important;
+}
 
 /* Sidebar — square corners, mono group headers, sans link font.
    Explicitly highlight the active page so it's clearly visible in both light

--- a/v3/developer/getting-started/quickstart.mdx
+++ b/v3/developer/getting-started/quickstart.mdx
@@ -268,19 +268,19 @@ curl -X POST https://api.gocobalt.io/api/v2/public/event/contact-created \
 You've successfully tested a Refold integration! Here's what to explore next:
 
 <CardGroup cols={2}>
-<Card title="Build Your First Integration" href="/getting-started/first-integration">
+<Card title="Build Your First Integration" href="/v3/embedded/getting-started/first-integration">
 Create a custom integration from scratch for your specific use case
 </Card>
 
-<Card title="Understanding Workflows" href="/workflows/fundamentals">
+<Card title="Understanding Workflows" href="/v3/developer/configure/workflows/overview">
 Learn how to build complex workflows with triggers, actions, and data transformation
 </Card>
 
-<Card title="Authentication Guide" href="/platform/authentication">
+<Card title="Authentication Guide" href="/v3/developer/configure/app-configuration/authentication">
 Set up OAuth apps and API keys for production use
 </Card>
 
-<Card title="Frontend SDK" href="/building-your-frontend/overview">
+<Card title="Frontend SDK" href="/v3/embedded/frontend/overview">
 Integrate Refold's auth flow directly into your application
 </Card>
 </CardGroup>


### PR DESCRIPTION
Two small, self-contained fixes (no MCP-rework content — those live in #217).

## Changes
- **In-content tab active-state** (`style.css`): the active `<Tabs>` tab now gets an electric-blue label + 2px blue underline (lighter blue in dark mode). Mintlify's default indicator was a thin gray underline the same color as the label, so the selected tab — e.g. the **OAuth 2.0** vs **Key-based** credentials tabs on the quickstart — was hard to tell apart. Applies to every `<Tabs>` across the docs, both light and dark mode.
- **Quickstart broken links** (`v3/developer/getting-started/quickstart.mdx`): four card links dropped the `/v3` prefix and 404'd. Repointed to the canonical in-nav pages:
  - Build Your First Integration → `/v3/embedded/getting-started/first-integration`
  - Understanding Workflows → `/v3/developer/configure/workflows/overview`
  - Authentication Guide → `/v3/developer/configure/app-configuration/authentication`
  - Frontend SDK → `/v3/embedded/frontend/overview`

## Verification
- Active tab computed styles confirmed: `#0057FF` label, 2px `#0057FF` underline, weight 600 (vs gray inactive).
- All four link targets verified to exist and be in `docs.json` navigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)