### PR TITLE
Platform overview + API-first quickstart

### DIFF
--- a/.claude/skills/claude-doc-style/SKILL.md
+++ b/.claude/skills/claude-doc-style/SKILL.md
@@ -92,7 +92,7 @@ landing pages. Use them rather than inventing a new order per page.
 
 ## Sentence style in four rules
 
-The full rule set with examples is in `references/sentence-style.md`. The four
+The full rule set with examples is in `references/sentence-style.md`. The five
 that matter most:
 
 1. **Talk to the reader as "you," in the present tense, doing the action now.**
@@ -110,6 +110,12 @@ that matter most:
 
 4. **Show the concrete token, ID, or path inline.** "(for example,
    `wrkspc_01JwQvzr7rXLA5AGx3HKfFUJ`)". Readers trust docs that show real values.
+
+5. **Never use em dashes (`—`) in content.** They read as AI-generated. Rewrite
+   the sentence with a period, comma, colon, or parentheses instead. "Build in
+   the browser. No deploy needed." not "Build in the browser — no deploy." This
+   applies to page prose, card and step text, table cells, and callouts. (Hyphens
+   in compound words like `AI-native` are fine; the ban is the em dash only.)
 
 ---
 
@@ -143,7 +149,8 @@ directly onto components — see `mintlify-design` for the syntax, but the
 - Is every multi-step procedure in `<Steps>`?
 - Has every constraint/warning/shortcut been pulled into a callout?
 - Does the page route the reader somewhere at the end?
-- Read it aloud: any sentence you stumble on is too long — split it.
+- Are there zero em dashes (`—`) anywhere in the content?
+- Read it aloud: any sentence you stumble on is too long, so split it.
 
 If you're writing for Refold specifically, also run the `refold-voice` checklist
 (terminology, product names) and the `mintlify-design` checklist (component and

--- a/docs.json
+++ b/docs.json
@@ -76,14 +76,6 @@
                 ]
               },
               {
-                "group": "Products",
-                "pages": [
-                  "v3/developer/products/native",
-                  "v3/developer/products/integration-delivery",
-                  "v3/developer/products/mcp"
-                ]
-              },
-              {
                 "group": "Concepts",
                 "pages": [
                   "v3/developer/configure/linked-account",

--- a/style.css
+++ b/style.css
@@ -12,6 +12,7 @@
   --rf-charcoal:        #191B20;
   --rf-charcoal-2:      #2D3036;
   --rf-electric-blue:   #0057FF;
+  --rf-electric-blue-light: #4D8AFF;
   --rf-sky-cyan:        #04CFFF;
   --rf-lime-mist:       #D8FF70;
   --rf-warn:            #F23E11;
@@ -37,10 +38,14 @@
   --rf-font-sans:  "DM Sans", system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
   --rf-font-mono:  "DM Mono", ui-monospace, "SFMono-Regular", Menlo, monospace;
 
-  /* Mintlify primary color overrides */
-  --primary: var(--rf-electric-blue);
-  --primary-light: #4D8AFF;
-  --primary-dark: #003FB5;
+  /* Mintlify primary color overrides.
+     Mintlify utilities use rgb(var(--primary) / <alpha>), so --primary and
+     --primary-light MUST be space-separated RGB channels, not hex. A hex value
+     here makes rgb(#0057FF / 1) invalid and silently breaks every masked card
+     icon (they render transparent). Keep these as channels. */
+  --primary: 0 87 255;          /* #0057FF */
+  --primary-light: 77 138 255;  /* #4D8AFF */
+  --primary-dark: #003FB5;      /* custom-only; used as a full color below */
 }
 
 /* ============================================================
@@ -130,8 +135,8 @@ h1, h2, h3, h4, h5, h6,
 }
 .dark #content-area [role="tab"][aria-selected="true"],
 .dark #content-area [class*="tab"] button[aria-selected="true"] {
-  color: var(--primary-light) !important;
-  border-bottom-color: var(--primary-light) !important;
+  color: var(--rf-electric-blue-light) !important;
+  border-bottom-color: var(--rf-electric-blue-light) !important;
 }
 
 /* Sidebar — square corners, mono group headers, sans link font.

--- a/v3/developer/configure/linked-account.mdx
+++ b/v3/developer/configure/linked-account.mdx
@@ -56,7 +56,7 @@ API to provision them programmatically.
 
     ```bash cURL
     curl --request POST \
-      --url https://api.gocobalt.io/api/v2/public/linked-account \
+      --url https://app.refold.ai/api/v2/public/linked-account \
       --header 'Content-Type: application/json' \
       --header 'x-api-key: YOUR_API_KEY' \
       --data '{
@@ -101,7 +101,7 @@ API to provision them programmatically.
 
 After a customer authenticates, you can adjust the configuration for any of
 their connected applications. For example, set field values or enable and
-disable specific workflows for that customer.
+disable specific [workflows](/v3/developer/configure/workflows/overview) for that customer.
 
 <Steps>
   <Step title="Open the integration's configuration">
@@ -212,16 +212,16 @@ Refold substitutes the linked account's value at execution time.
 ## Next steps
 
 <CardGroup cols={2}>
-  <Card title="Auth flows" href="/v3/developer/guide/ship/auth_flows/hosted">
+  <Card title="Auth flows" icon="key" href="/v3/developer/guide/ship/auth_flows/hosted">
     Let customers connect their own accounts.
   </Card>
-  <Card title="Logs" href="/v3/developer/monitor/logs">
+  <Card title="Logs" icon="clipboard-list" href="/v3/developer/monitor/logs">
     Understand each log type Refold records.
   </Card>
-  <Card title="Workflows" href="/v3/developer/configure/workflows/overview">
+  <Card title="Workflows" icon="diagram-project" href="/v3/developer/configure/workflows/overview">
     Automate what happens after a customer connects.
   </Card>
-  <Card title="API reference" href="/v3/api-reference/linked-accounts/create-linked-account">
+  <Card title="API reference" icon="code" href="/v3/api-reference/linked-accounts/create-linked-account">
     Create, update, and delete linked accounts programmatically.
   </Card>
 </CardGroup>

--- a/v3/developer/getting-started/overview.mdx
+++ b/v3/developer/getting-started/overview.mdx
@@ -1,8 +1,49 @@
 ---
 title: "Overview"
-description: "Introduction to Refold platform"
+description: "The AI-native enterprise integration platform. Cut integration timelines from years to weeks and costs by more than half."
 ---
 
-# Overview
+Refold is the AI-native enterprise integration platform that cuts your integration timelines from years to weeks and costs by more than half. It is built on deep expertise in SAP, Salesforce, Workday, Oracle, and 300+ other applications, so every integration ships governed, tested, and ready for production.
 
-Content coming soon.
+## Recommended path for new developers
+
+<Steps>
+  <Step title="Log in to Refold">
+    Log in at [app.refold.ai](https://app.refold.ai).
+
+    <Info>
+      Don't have an account yet? [Contact us](https://www.refold.ai/contact-us) to set one up.
+    </Info>
+  </Step>
+  <Step title="Make your first API call">
+    Grab your API key from **Settings > Credentials** in the [Refold Console](https://uat.refold.ai/settings/credentials), then make your first request. See the [quickstart](/v3/developer/getting-started/quickstart) for a complete walkthrough.
+  </Step>
+  <Step title="Explore platform features">
+    Dig into platform features like [workflows](/v3/developer/configure/workflows/overview), [linked accounts](/v3/developer/configure/linked-account), and [connectors](/v3/developer/configure/connector/supported-apps-actions).
+  </Step>
+</Steps>
+
+## Develop with Refold
+
+<CardGroup cols={3}>
+  <Card title="Refold Console" icon="laptop" href="https://app.refold.ai">
+    Build, test, and ship integrations in the browser. No deploy needed.
+  </Card>
+  <Card title="API Reference" icon="code" href="/v3/api-reference/overview">
+    Full reference for the v3 REST API, webhooks, and event payloads.
+  </Card>
+  <Card title="SDKs" icon="code-branch" href="/v3/api-reference/sdks">
+    Node, React, and browser-JS SDKs for server- and client-side flows.
+  </Card>
+</CardGroup>
+
+## Support
+
+<CardGroup cols={2}>
+  <Card title="Status" icon="cloud" href="https://status.refold.ai">
+    Check the live status of Refold services.
+  </Card>
+  <Card title="Changelog" icon="newspaper" href="/v3/changelog/overview">
+    Release notes for the platform and every product.
+  </Card>
+</CardGroup>

--- a/v3/developer/getting-started/quickstart.mdx
+++ b/v3/developer/getting-started/quickstart.mdx
@@ -1,290 +1,130 @@
 ---
 title: "Quick Start"
-description: "Get your first integration running in 5 minutes"
+description: "Connect a real app and trigger your first integration through the Refold API in about 10 minutes."
 ---
 
+Refold connects your product to third-party apps through linked accounts, connectors, and workflows. This quickstart runs that loop end to end: get an API key, configure an app, connect it to a linked account, and run your first integration through the API. Plan about 10 minutes.
 
-Get up and running with Refold in under 10 minutes. You'll test a complete integration workflow and see real data flowing between applications.
+## Prerequisites
 
-## What You'll Accomplish
+- **A Refold account.** Log in at [app.refold.ai](https://app.refold.ai). Don't have one? [Contact us](https://www.refold.ai/contact-us) to get set up.
+- **No third-party credentials needed.** This quickstart uses the **Playground app** (`playground_app`), a built-in test connector for running the full loop.
 
-By the end of this guide, you'll have:
-- ✅ Tested a live integration workflow
-- ✅ Seen data sync between your app and a third-party platform
-- ✅ Understanding of how Refold's core components work together
+<Note>
+  Every API call uses the base URL `https://app.refold.ai` and sends your API key in the `x-api-key` header. Account-scoped calls also send the customer's `linked_account_id` as a header.
+</Note>
 
-<Info>
-**Before you start**: You'll need a Refold account. [Sign up here](https://app.gocobalt.io/) if you haven't already.
-</Info>
-
----
-
-## Step 1: Choose Your Test Integration
-
-Navigate to your Refold dashboard and pick an integration to test.
+## Get your API key
 
 <Steps>
-<Step title="Go to Apps">
-In your Refold dashboard, click **Apps** in the sidebar. You'll see all available integrations.
+  <Step title="Open Settings > Credentials">
+    In the [Refold Console](https://uat.refold.ai/settings/credentials), go to **Settings > Credentials**.
+  </Step>
+  <Step title="Copy your key">
+    Copy your API key and export it as an environment variable so the commands below can read it.
 
-<img height="200" src="/images/quickstart/apps-sidebar.png" alt="Apps section in Refold sidebar navigation" />
-</Step>
-
-<Step title="Pick an Integration">
-Choose any integration you have credentials for (HubSpot, Salesforce, Slack, etc.). For this guide, we'll use **HubSpot** as an example.
-
-<img height="300" src="/images/quickstart/apps-catalog.png" alt="Apps catalog showing available integrations" />
-</Step>
-
-<Step title="Check Demo Workflows">
-Click on your chosen integration → **Workflows** tab. You'll see pre-built demo workflows ready to test.
-
-<img height="250" src="/images/quickstart/demo-workflows.png" alt="Demo workflows available in HubSpot integration" />
-</Step>
+    ```bash
+    export REFOLD_API_KEY="your-api-key-here"
+    ```
+  </Step>
 </Steps>
 
----
+## Configure the Playground app
 
-## Step 2: Configure Integration Credentials
-
-You need to authenticate with the third-party app to test data flow.
+Before a customer can connect an app, configure how Refold authenticates with it. The Playground app uses key-based auth.
 
 <Steps>
-<Step title="Check Authentication Type">
-Go to **Apps** → [Your Integration] → **Settings**. You'll see either:
-- **OAuth 2.0**: Requires app credentials (Client ID, Secret)
-- **Key-based**: Requires API keys
+  <Step title="Open the Playground app">
+    Go to **Apps > Playground app > Settings**.
+  </Step>
+  <Step title="Choose the auth method">
+    Select **Key-based**, add the **API key**, and click **Save**.
+  </Step>
+</Steps>
 
-<img height="200" src="/images/quickstart/auth-type-settings.png" alt="Integration settings showing authentication type" />
-</Step>
+<Note>
+  Real connectors may use OAuth 2.0 instead of key-based auth. See [Authentication](/v3/developer/configure/app-configuration/authentication) to set up an OAuth app for production.
+</Note>
 
-<Step title="Set Up Credentials">
+## Create a linked account
 
-<Tabs>
-<Tab title="OAuth 2.0 (Recommended)">
-```text
-1. Click "Use Our Credentials" for quick testing
-   OR
-2. Click "Read Documentation" to set up your own app
-3. Add Client ID and Client Secret in Settings
-4. Click Save
+A linked account represents one of your customers. Create one through the API. You choose the `linked_account_id`, then reuse it in every account-scoped call.
+
+```bash cURL
+curl -X POST https://app.refold.ai/api/v2/public/linked-account \
+  -H "x-api-key: $REFOLD_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "linked_account_id": "demo-user-1",
+    "name": "Demo User"
+  }'
 ```
-</Tab>
 
-<Tab title="Key-based">
-```text
-1. Click "Read Documentation" to get API keys
-2. Follow the setup guide for your integration
-3. Add API Key and other credentials in Settings
-4. Click Save
+```json Output
+{ "success": true }
 ```
-</Tab>
-</Tabs>
 
-<img height="250" src="/images/quickstart/oauth-credentials-setup.png" alt="OAuth credentials configuration in app settings" />
-</Step>
-</Steps>
+## Connect the app
 
-<Tip>
-**Quick tip**: Use "Our Credentials" for testing. You can switch to your own credentials later for production.
-</Tip>
+Generate a [Connect portal](/v3/embedded/frontend/overview) URL for the linked account, then open it to connect the app.
 
----
+```bash cURL
+curl -X POST https://app.refold.ai/api/v2/public/connect-url \
+  -H "x-api-key: $REFOLD_API_KEY" \
+  -H "linked_account_id: demo-user-1" \
+  -H "Content-Type: application/json" \
+  -d '{ "name": "Demo User" }'
+```
 
-## Step 3: Set Up Response Testing
-
-Configure where you'll receive the workflow response to see the integration working.
-
-<Steps>
-<Step title="Get Your Test URL">
-1. Go to [webhook.site](https://webhook.site)
-2. Copy **Your unique URL** (looks like: `https://webhook.site/abc123...`)
-
-<img height="200" src="/images/quickstart/webhook-site-url.png" alt="Webhook.site showing unique URL for testing" />
-</Step>
-
-<Step title="Find the API Proxy">
-1. In your chosen workflow, look for the **Native node** at the end
-2. Note the **Action name** (e.g., "Create Contact", "Send Message")
-
-<img height="250" src="/images/quickstart/workflow-native-node.png" alt="Workflow showing native node with API proxy action" />
-</Step>
-
-<Step title="Configure the Proxy">
-1. Go to **Developers** → **API Proxies**
-2. Search for your Action name
-3. Click on it and select **API Call** tab
-4. Paste your webhook.site URL in **Request URL**
-5. Click **Save API Call**
-
-<img height="300" src="/images/quickstart/api-proxy-configuration.png" alt="API Proxy configuration with webhook URL setup" />
-</Step>
-</Steps>
-
----
-
-## Step 4: Connect a Test User
-
-Create a linked account to represent your end user and authenticate them.
+```json Output
+{ "hosted_url": "https://connect.gocobalt.io/eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..." }
+```
 
 <Steps>
-<Step title="Create Linked Account">
-1. Go to **Linked Accounts** → **+ Add Account**
-2. Enter a test name (e.g., "Test User")
-3. Click **Create**
-
-<img height="200" src="/images/quickstart/create-linked-account.png" alt="Creating a new linked account" />
-</Step>
-
-<Step title="Generate Hosted URL">
-1. Open your test linked account
-2. Click **Get Hosted URL** → **Generate Hosted URL**
-3. Copy the URL and open it in a new tab
-
-<img height="250" src="/images/quickstart/generate-hosted-url.png" alt="Generating hosted URL for linked account" />
-</Step>
-
-<Step title="Connect Integration">
-1. In the hosted portal, find your integration
-2. Click **Connect** and complete authentication
-3. Enable the workflow you want to test
-4. Click **Save**
-
-<img height="300" src="/images/quickstart/hosted-portal-connect.png" alt="Hosted portal showing integration connection interface" />
-</Step>
+  <Step title="Open the Connect portal">
+    Open the `hosted_url` from the response in your browser.
+  </Step>
+  <Step title="Connect the Playground app">
+    Find the **Playground app**, click **Connect**, and complete authentication.
+  </Step>
 </Steps>
 
-<Info>
-The **Hosted Portal** is Refold's no-code authentication UI. Later, you can build your own UI using our SDKs.
-</Info>
+<Note>
+  The Connect portal is Refold's hosted connection UI. You can build your own with the [frontend SDKs](/v3/embedded/frontend/overview).
+</Note>
 
----
+## Trigger your first integration
 
-## Step 5: Test Your Integration
+With the app connected, run a published workflow for the linked account through the workflow API. Pass the workflow's ID in the path and the Playground app's slug, `playground_app`, in the `slug` header.
 
-Now trigger the workflow and watch data flow.
+<Note>
+  The workflow must be **published** before you can run it. Get its ID from [List Workflows](/v3/api-reference/workflows/list-workflows) or the Console.
+</Note>
 
-<Steps>
-<Step title="Trigger the Workflow">
+```bash cURL
+curl -X POST https://app.refold.ai/api/v2/public/workflow/YOUR_WORKFLOW_ID/execute \
+  -H "x-api-key: $REFOLD_API_KEY" \
+  -H "linked_account_id: demo-user-1" \
+  -H "slug: playground_app" \
+  -H "Content-Type: application/json" \
+  -d '{ "payload": { "email": "jane@example.com" } }'
+```
 
-**For Event-Based Workflows:**
-1. Go to **Try API** in Refold
-2. Select your event (e.g., "Contact Created")
-3. Add test data:
-
-```json
+```json Output
 {
-  "name": "John Doe",
-  "email": "john@example.com",
-  "company": "Test Company"
+  "message": "Workflow execution started",
+  "execution_id": "6a314c54d4616e99e7fa5a02"
 }
 ```
 
-4. Click **Fire Event**
+Refold acknowledges with an `execution_id` and starts the run. Open **Logs** in the Console to follow it. To get the workflow output inline instead, add the `sync_execution: true` header. For every option, see [Execute Workflow](/v3/api-reference/workflows/execute-workflow).
 
-<img height="300" src="/images/quickstart/try-api-fire-event.png" alt="Try API section with event firing interface" />
+## Choose your product
 
-**For App-Based Triggers:**
-Create a test record directly in your connected app (e.g., add a contact in HubSpot)
-</Step>
+You've run the core loop. Now pick the product that fits how you ship integrations.
 
-<Step title="Check Execution">
-1. Go to **Logs** in Refold
-2. Find your workflow execution
-3. Check the status and any error messages
-
-<img height="250" src="/images/quickstart/execution-logs.png" alt="Workflow execution logs showing successful run" />
-</Step>
-
-<Step title="Verify Results">
-1. Check your webhook.site for the API response
-2. Verify data was created/updated in the target app
-3. 🎉 **Success!** You've completed your first integration test
-
-<img height="200" src="/images/quickstart/webhook-response.png" alt="Webhook.site showing successful API response" />
-</Step>
-</Steps>
-
----
-
-## See It in Action
-
-Here's what just happened behind the scenes:
-
-<CodeGroup>
-```javascript JavaScript
-// This is what Refold did when you fired the event
-const response = await fetch('https://api.gocobalt.io/api/v2/public/event/contact-created', {
-  method: 'POST',
-  headers: {
-    'Authorization': 'Bearer YOUR_API_KEY',
-    'Content-Type': 'application/json'
-  },
-  body: JSON.stringify({
-    linked_account_id: 'your-linked-account-id',
-    data: {
-      name: 'John Doe',
-      email: 'john@example.com',
-      company: 'Test Company'
-    }
-  })
-});
-
-console.log('Workflow triggered:', response.status);
-```
-
-```bash cURL
-curl -X POST https://api.gocobalt.io/api/v2/public/event/contact-created \
-  -H "Authorization: Bearer YOUR_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "linked_account_id": "your-linked-account-id",
-    "data": {
-      "name": "John Doe",
-      "email": "john@example.com", 
-      "company": "Test Company"
-    }
-  }'
-```
-</CodeGroup>
-
----
-
-## Troubleshooting
-
-<Warning>
-**Common Issues:**
-
-- **Authentication failed**: Double-check your credentials in App Settings
-- **Workflow not triggering**: Ensure the workflow is enabled in the hosted portal
-- **No response at webhook.site**: Verify the API Proxy URL is configured correctly
-- **Missing scopes**: Add required permissions in App Settings → Permissions & Scopes
-</Warning>
-
----
-
-## What's Next?
-
-You've successfully tested a Refold integration! Here's what to explore next:
-
-<CardGroup cols={2}>
-<Card title="Build Your First Integration" href="/v3/embedded/getting-started/first-integration">
-Create a custom integration from scratch for your specific use case
-</Card>
-
-<Card title="Understanding Workflows" href="/v3/developer/configure/workflows/overview">
-Learn how to build complex workflows with triggers, actions, and data transformation
-</Card>
-
-<Card title="Authentication Guide" href="/v3/developer/configure/app-configuration/authentication">
-Set up OAuth apps and API keys for production use
-</Card>
-
-<Card title="Frontend SDK" href="/v3/embedded/frontend/overview">
-Integrate Refold's auth flow directly into your application
-</Card>
-</CardGroup>
-
----
-
-**Ready to build something real?** Continue to [First Integration](/getting-started/first-integration) where you'll create a production-ready integration from scratch.
+| Product | Who it's for |
+|---------|--------------|
+| [**Native**](/v3/embedded/overview) | SaaS teams embedding third-party integrations inside their own product |
+| [**Integration Delivery**](/v3/project/overview) | Teams delivering bespoke enterprise integrations to their customers |
+| [**MCP**](/v3/mcp-ai-agents/overview/what-is-mcp) | AI teams giving agents secure, governed access to enterprise systems |


### PR DESCRIPTION
## What

Rewrites the Platform **Overview** and **Quickstart** pages to match the Claude-docs pattern, and reorganizes product discovery.

### Overview (`v3/developer/getting-started/overview.mdx`)
- Sharp, value-led positioning: "the AI-native enterprise integration platform… years to weeks, costs by more than half."
- `Recommended path` Steps (log in → first API call → explore features), `Develop with Refold` and `Support` card groups.

### Quickstart (`v3/developer/getting-started/quickstart.mdx`)
- API-first full loop that ends on a real action: get key → configure the **Playground app** (`playground_app`, key-based) → create + connect a linked account → **run a workflow via the workflow API**.
- All calls use `https://app.refold.ai` (verified serving; `api.refold.ai` does not resolve yet).
- Ends with a **Choose your product** table.

### Navigation (`docs.json`)
- Removes the redundant **Products** group from the Platform tab (Native / Integration Delivery / MCP are already top-level tabs). Product discovery now lives at the end of the quickstart.

### Fixes / tooling
- **`style.css`**: card icons rendered blank site-wide because `--primary`/`--primary-light` were hex; Mintlify's `rgb(var(--primary)/<a>)` utilities need RGB channels. Converted to channels and repointed the two custom usages to a new `--rf-electric-blue-light` var.
- **`claude-doc-style` skill**: added a no-em-dash rule.

## Notes
- API host is `app.refold.ai`; the Connect portal response still returns a `connect.gocobalt.io` URL (real API behavior).
- Workflow call uses a `YOUR_WORKFLOW_ID` placeholder; can hardcode a Playground demo workflow ID if one exists.
- Orphaned `v3/developer/products/*` pages are now unreferenced in nav (left on disk).

## Verification
Verified live in `mintlify dev`: both pages render with no MDX errors, zero em dashes, all card icons render, nav updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)