### PR TITLE
docs(v3): show v1 in version dropdown; hide Integration Delivery tab

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -1726,7 +1726,8 @@
                   "v3/project/examples/multi-system"
                 ]
               }
-            ]
+            ],
+            "hidden": true
           },
           {
             "tab": "MCP",
@@ -2006,6 +2007,157 @@
                   },
                   "v3/changelog/2025",
                   "v3/changelog/2024"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "version": "v1",
+        "tabs": [
+          {
+            "tab": "Documentation",
+            "groups": [
+              {
+                "group": "Documentation",
+                "pages": [
+                  "legacy/introduction",
+                  "legacy/quickstart",
+                  "legacy/glossary"
+                ]
+              },
+              {
+                "group": "Implementation Guide",
+                "pages": [
+                  "legacy/implement/implementation/overview",
+                  {
+                    "group": "Integrate",
+                    "pages": [
+                      "legacy/implement/implementation/integrate/cobalt-account",
+                      "legacy/implement/implementation/integrate/setup-linked-account",
+                      "legacy/implement/implementation/integrate/get-access-token",
+                      "legacy/implement/implementation/integrate/display-apps",
+                      "legacy/implement/implementation/integrate/manage-connection",
+                      "legacy/implement/implementation/integrate/end-user-config"
+                    ]
+                  },
+                  {
+                    "group": "Communicate",
+                    "pages": [
+                      "legacy/implement/implementation/communicate/write-data",
+                      "legacy/implement/implementation/communicate/get-data"
+                    ]
+                  },
+                  {
+                    "group": "Test Integration",
+                    "pages": [
+                      "legacy/implement/implementation/Test-Integration/develop-test",
+                      "legacy/implement/implementation/Test-Integration/node-test",
+                      "legacy/implement/implementation/Test-Integration/orchestration-test"
+                    ]
+                  },
+                  {
+                    "group": "Additional",
+                    "pages": [
+                      "legacy/implement/implementation/additional/reauth",
+                      "legacy/implement/implementation/additional/workflow-failure",
+                      "legacy/implement/implementation/additional/workflow-access"
+                    ]
+                  },
+                  {
+                    "group": "Deploy",
+                    "pages": [
+                      "legacy/implement/implementation/deploy/live-checklist"
+                    ]
+                  }
+                ]
+              },
+              {
+                "group": "Concepts",
+                "pages": [
+                  "legacy/concepts/linked_account",
+                  {
+                    "group": "Auth Flows",
+                    "pages": [
+                      "legacy/concepts/auth-flows/auth-flows",
+                      "legacy/concepts/auth-flows/re-auth-flow"
+                    ]
+                  },
+                  "legacy/concepts/logs",
+                  {
+                    "group": "Workflow",
+                    "pages": [
+                      "legacy/concepts/workflow/overview",
+                      "legacy/concepts/workflow/workflow_api",
+                      "legacy/concepts/workflow/workflow_testing",
+                      "legacy/concepts/workflow/templating",
+                      "legacy/concepts/workflow/dataslots",
+                      {
+                        "group": "Nodes",
+                        "pages": [
+                          "legacy/concepts/workflow/custom-code",
+                          "legacy/concepts/workflow/datastore",
+                          "legacy/concepts/workflow/delay",
+                          "legacy/concepts/workflow/group",
+                          "legacy/concepts/workflow/httpnode",
+                          "legacy/concepts/workflow/merge",
+                          "legacy/concepts/workflow/pdf",
+                          "legacy/concepts/workflow/response",
+                          "legacy/concepts/workflow/rule",
+                          "legacy/concepts/workflow/email",
+                          "legacy/concepts/workflow/transform"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "group": "App Config",
+                    "pages": [
+                      "legacy/concepts/application/how-to-configure",
+                      "legacy/concepts/application/mapping",
+                      "legacy/concepts/application/dependent",
+                      "legacy/concepts/application/field-types"
+                    ]
+                  },
+                  "legacy/concepts/integration",
+                  {
+                    "group": "Custom Apps",
+                    "pages": [
+                      "legacy/concepts/advance-concepts/about-custom-apps",
+                      "legacy/concepts/advance-concepts/setting-up-custom-app"
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "tab": "Guides",
+            "groups": [
+              {
+                "group": "Developer Settings",
+                "pages": [
+                  "legacy/guides-v1v2/developer-settings/overview",
+                  "legacy/guides-v1v2/developer-settings/events",
+                  "legacy/guides-v1v2/developer-settings/api_proxy"
+                ]
+              },
+              {
+                "group": "Platform",
+                "pages": [
+                  {
+                    "group": "Account Management",
+                    "pages": [
+                      "legacy/guides-v1v2/platform/account-management/general",
+                      "legacy/guides-v1v2/platform/account-management/users",
+                      "legacy/guides-v1v2/platform/account-management/access",
+                      "legacy/guides-v1v2/platform/account-management/branding"
+                    ]
+                  },
+                  "legacy/guides-v1v2/platform/webhook",
+                  "legacy/guides-v1v2/platform/tables",
+                  "legacy/guides-v1v2/platform/tryapi"
                 ]
               }
             ]


### PR DESCRIPTION
## Summary

Two version-switcher / navigation tweaks for the v3 docs, plus a small fix:

- **Show v1 again** in the version dropdown. v1 was previously removed from the switcher; this re-adds it to `navigation.versions` (order: **v2** default → **v3** → **v1**). v1 content was never deleted.
- **Hide the "Integration Delivery" tab** in v3 using `"hidden": true`. The tab definition and all its pages are kept — it's just removed from the v3 tab bar (easy to re-enable by flipping the flag).
- **Fix 10 stale v1 nav paths** (`legacy/guides/*` → `legacy/guides-v1v2/*`) so the restored v1 navigation resolves to real files.

## Verification (local preview)

- ✅ `docs.json` valid JSON; all 680 nav pages resolve (0 missing)
- ✅ v3 tab bar now renders **Platform, Native, MCP, API references & SDK, Changelog** — Integration Delivery no longer shown
- ✅ Served version switcher includes **v1, v2, v3**
- ✅ Broken links unchanged at baseline (500), no syntax errors

## Notes

- Base branch is `abhishek` (the v3 integration branch feeding the launch PR #232). Retarget to `main` if you'd prefer this to go directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)