### PR TITLE
Revert "Fix for API Playground: Default x-api-key from docs.json removed"

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -2035,6 +2035,11 @@
   "openapi": "v3/api-reference/openapi.yaml",
   "api": {
     "baseUrl": "https://app.refold.ai",
+    "auth": {
+      "method": "key",
+      "name": "x-api-key",
+      "inputPrefix": "<Your Refold API key>"
+    },
     "playground": {
       "mode": "simple"
     }

--- a/legacy/api-reference/applications/execute-action.mdx
+++ b/legacy/api-reference/applications/execute-action.mdx
@@ -1,6 +1,6 @@
 ---
 title: Execute Action
-api: post /api/v2/integration-schema/{slug}/actions/{action_id}/execute
+api: post /api/v2/integration-schema/:slug/actions/:action_id/execute
 description: Execute an application action against a connected account.
 ---
 

--- a/legacy/api-reference/applications/get-action-parameters.mdx
+++ b/legacy/api-reference/applications/get-action-parameters.mdx
@@ -1,6 +1,6 @@
 ---
 title: Get Action Schema
-api: get /api/v2/integration-schema/{slug}/actions/{action_id}
+api: get /api/v2/integration-schema/:slug/actions/:action_id
 description: Get the parameter schema for an application action.
 ---
 

--- a/legacy/api-reference/applications/get-actions.mdx
+++ b/legacy/api-reference/applications/get-actions.mdx
@@ -1,6 +1,6 @@
 ---
 title: List Actions
-api: get /api/v2/integration-schema/{slug}/actions
+api: get /api/v2/integration-schema/:slug/actions
 description: List the available actions for a connected application.
 ---
 

--- a/legacy/api-reference/applications/get-application.mdx
+++ b/legacy/api-reference/applications/get-application.mdx
@@ -1,6 +1,6 @@
 ---
 title: Get Application
-api: get /api/v2/public/application/{slug}
+api: get /api/v2/public/application/:slug
 description: Retrieve details of a specific application by its slug.
 ---
 

--- a/legacy/api-reference/auth-structure/get-auth-structure.mdx
+++ b/legacy/api-reference/auth-structure/get-auth-structure.mdx
@@ -1,6 +1,6 @@
 ---
 title: Get Auth Structure
-api: get /api/v2/public/auth-structure/{slug}
+api: get /api/v2/public/auth-structure/:slug
 description: Get the authentication field structure for an app.
 ---
 

--- a/legacy/api-reference/auth-structure/get-oauth-url.mdx
+++ b/legacy/api-reference/auth-structure/get-oauth-url.mdx
@@ -1,6 +1,6 @@
 ---
 title: Get OAuth URL
-api: get /api/v2/public/linked-account/integration/oauth-url/{slug}
+api: get /api/v2/public/linked-account/integration/oauth-url/:slug
 description: Get the OAuth authorization URL for an app.
 ---
 

--- a/legacy/api-reference/config-fields/delete-field-value.mdx
+++ b/legacy/api-reference/config-fields/delete-field-value.mdx
@@ -1,6 +1,6 @@
 ---
 title: Clear Config Field Value
-api: delete /api/v2/public/config/field/{fieldId}
+api: delete /api/v2/public/config/field/:fieldId
 description: Clear the value of a single config field.
 ---
 

--- a/legacy/api-reference/config-fields/get-field-by-id.mdx
+++ b/legacy/api-reference/config-fields/get-field-by-id.mdx
@@ -1,6 +1,6 @@
 ---
 title: Get Config Field Options
-api: post /api/v2/public/config/field/{fieldId}
+api: post /api/v2/public/config/field/:fieldId
 description: Resolve the options for a single config field.
 ---
 

--- a/legacy/api-reference/config-fields/get-options-for-rule-engine.mdx
+++ b/legacy/api-reference/config-fields/get-options-for-rule-engine.mdx
@@ -1,6 +1,6 @@
 ---
 title: Get Rule Engine Options
-api: post /api/v2/public/config/rule-engine/{fieldId}
+api: post /api/v2/public/config/rule-engine/:fieldId
 description: Resolve column options for a rule-engine config field.
 ---
 

--- a/legacy/api-reference/config-fields/update-field-value.mdx
+++ b/legacy/api-reference/config-fields/update-field-value.mdx
@@ -1,6 +1,6 @@
 ---
 title: Update Config Field Value
-api: put /api/v2/public/config/field/{fieldId}
+api: put /api/v2/public/config/field/:fieldId
 description: Set the value of a single config field.
 ---
 

--- a/legacy/api-reference/configs/delete-config-default.mdx
+++ b/legacy/api-reference/configs/delete-config-default.mdx
@@ -1,6 +1,6 @@
 ---
 title: Delete Config
-api: delete /api/v2/public/slug/{slug}/config
+api: delete /api/v2/public/slug/:slug/config
 description: Delete the installed config for an app (config ID defaulted).
 ---
 

--- a/legacy/api-reference/configs/delete-config.mdx
+++ b/legacy/api-reference/configs/delete-config.mdx
@@ -1,6 +1,6 @@
 ---
 title: Delete Config by ID
-api: delete /api/v2/public/slug/{slug}/config/{config_id}
+api: delete /api/v2/public/slug/:slug/config/:config_id
 description: Delete a config installation by config ID.
 ---
 

--- a/legacy/api-reference/configs/get-config-default.mdx
+++ b/legacy/api-reference/configs/get-config-default.mdx
@@ -1,6 +1,6 @@
 ---
 title: Get Config
-api: get /api/v2/public/slug/{slug}/config
+api: get /api/v2/public/slug/:slug/config
 description: Get the installed config for an app (config ID defaulted).
 ---
 

--- a/legacy/api-reference/configs/get-config.mdx
+++ b/legacy/api-reference/configs/get-config.mdx
@@ -1,6 +1,6 @@
 ---
 title: Get Config by ID
-api: get /api/v2/public/slug/{slug}/config/{config_id}
+api: get /api/v2/public/slug/:slug/config/:config_id
 description: Get an installed config for an app and config ID.
 ---
 

--- a/legacy/api-reference/configs/list-configs.mdx
+++ b/legacy/api-reference/configs/list-configs.mdx
@@ -1,6 +1,6 @@
 ---
 title: List Config IDs
-api: get /api/v2/public/slug/{slug}/configs
+api: get /api/v2/public/slug/:slug/configs
 description: List the config IDs installed for an app on a linked account.
 ---
 

--- a/legacy/api-reference/configs/toggle-workflow.mdx
+++ b/legacy/api-reference/configs/toggle-workflow.mdx
@@ -1,6 +1,6 @@
 ---
 title: Toggle Workflow in Config
-api: patch /api/v2/public/slug/{slug}/config/{config_id}/workflows/{workflow_id}
+api: patch /api/v2/public/slug/:slug/config/:config_id/workflows/:workflow_id
 description: Enable or disable a workflow within a config.
 ---
 

--- a/legacy/api-reference/credentials/delete-default-app-credential.mdx
+++ b/legacy/api-reference/credentials/delete-default-app-credential.mdx
@@ -1,6 +1,6 @@
 ---
 title: Delete Default-App Credential
-api: delete /api/v2/public/linked-account/default-app/auth-credentials/{key}
+api: delete /api/v2/public/linked-account/default-app/auth-credentials/:key
 description: Remove a single auth credential from the org's default app.
 ---
 

--- a/legacy/api-reference/credentials/save-key-credentials.mdx
+++ b/legacy/api-reference/credentials/save-key-credentials.mdx
@@ -1,6 +1,6 @@
 ---
 title: Save Key Credentials
-api: put /api/v2/public/linked-account/integration/save-key-credentials/{slug}
+api: put /api/v2/public/linked-account/integration/save-key-credentials/:slug
 description: Save key-based credentials for an app on a linked account.
 ---
 

--- a/legacy/api-reference/credentials/upsert-default-app-credential.mdx
+++ b/legacy/api-reference/credentials/upsert-default-app-credential.mdx
@@ -1,6 +1,6 @@
 ---
 title: Upsert Default-App Credential
-api: put /api/v2/public/linked-account/default-app/auth-credentials/{key}
+api: put /api/v2/public/linked-account/default-app/auth-credentials/:key
 description: Add or update a single auth credential on the org's default app.
 ---
 

--- a/legacy/api-reference/datarefs/clear-records.mdx
+++ b/legacy/api-reference/datarefs/clear-records.mdx
@@ -1,6 +1,6 @@
 ---
 title: Clear Dataref Records
-api: put /api/v2/public/dataref/{refName}/clear-records
+api: put /api/v2/public/dataref/:refName/clear-records
 description: Clear all records of a dataref while keeping the dataref.
 ---
 

--- a/legacy/api-reference/datarefs/delete-dataref.mdx
+++ b/legacy/api-reference/datarefs/delete-dataref.mdx
@@ -1,6 +1,6 @@
 ---
 title: Delete Dataref
-api: delete /api/v2/public/dataref/{refName}
+api: delete /api/v2/public/dataref/:refName
 description: Delete a dataref for a linked account.
 ---
 

--- a/legacy/api-reference/datarefs/get-dataref.mdx
+++ b/legacy/api-reference/datarefs/get-dataref.mdx
@@ -1,6 +1,6 @@
 ---
 title: Get Dataref
-api: get /api/v2/public/dataref/{refName}
+api: get /api/v2/public/dataref/:refName
 description: Get a dataref's records as a table.
 ---
 

--- a/legacy/api-reference/deprecated/list-config-datastores.mdx
+++ b/legacy/api-reference/deprecated/list-config-datastores.mdx
@@ -1,6 +1,6 @@
 ---
 title: List Datastores
-api: get /api/v2/public/datastore/config/{slug}
+api: get /api/v2/public/datastore/config/:slug
 description: List the datastore names in an app's config.
 ---
 

--- a/legacy/api-reference/deprecated/list-records.mdx
+++ b/legacy/api-reference/deprecated/list-records.mdx
@@ -1,6 +1,6 @@
 ---
 title: Get Datastore Records
-api: get /api/v2/public/datastore/config/{slug}/{datastore}/records
+api: get /api/v2/public/datastore/config/:slug/:datastore/records
 description: Get all records from a config datastore.
 ---
 

--- a/legacy/api-reference/deprecated/search-records.mdx
+++ b/legacy/api-reference/deprecated/search-records.mdx
@@ -1,6 +1,6 @@
 ---
 title: Search Datastore Records
-api: post /api/v2/public/datastore/config/{slug}/{datastore_name}/search
+api: post /api/v2/public/datastore/config/:slug/:datastore_name/search
 description: Search records in a config datastore.
 ---
 

--- a/legacy/api-reference/environment-variables/delete-value.mdx
+++ b/legacy/api-reference/environment-variables/delete-value.mdx
@@ -1,6 +1,6 @@
 ---
 title: Delete Variable Value
-api: delete /api/v2/public/env/values/{value_id}
+api: delete /api/v2/public/env/values/:value_id
 description: Delete an environment-variable value by ID.
 ---
 

--- a/legacy/api-reference/environment-variables/get-definition.mdx
+++ b/legacy/api-reference/environment-variables/get-definition.mdx
@@ -1,6 +1,6 @@
 ---
 title: Get Variable Definition
-api: get /api/v2/public/env/definitions/{id}
+api: get /api/v2/public/env/definitions/:id
 description: Get an environment-variable definition by ID.
 ---
 

--- a/legacy/api-reference/environment-variables/get-value.mdx
+++ b/legacy/api-reference/environment-variables/get-value.mdx
@@ -1,6 +1,6 @@
 ---
 title: Get Variable Value
-api: get /api/v2/public/env/value/{definition_id}
+api: get /api/v2/public/env/value/:definition_id
 description: Resolve a single environment-variable value in its scope.
 ---
 

--- a/legacy/api-reference/environment-variables/list-values.mdx
+++ b/legacy/api-reference/environment-variables/list-values.mdx
@@ -1,6 +1,6 @@
 ---
 title: List Variable Values
-api: get /api/v2/public/env/values/{scope}
+api: get /api/v2/public/env/values/:scope
 description: List environment-variable values for a scope.
 ---
 

--- a/legacy/api-reference/events/delete-event.mdx
+++ b/legacy/api-reference/events/delete-event.mdx
@@ -1,6 +1,6 @@
 ---
 title: Delete Event
-api: delete /api/v2/public/application/event/{event_id}
+api: delete /api/v2/public/application/event/:event_id
 description: Remove a custom event from your org's default app.
 ---
 

--- a/legacy/api-reference/events/get-event.mdx
+++ b/legacy/api-reference/events/get-event.mdx
@@ -1,6 +1,6 @@
 ---
 title: Get Event
-api: get /api/v2/public/application/event/{event_id}
+api: get /api/v2/public/application/event/:event_id
 description: Get a single custom event from your org's default app.
 ---
 

--- a/legacy/api-reference/events/trigger-event-by-slug.mdx
+++ b/legacy/api-reference/events/trigger-event-by-slug.mdx
@@ -1,6 +1,6 @@
 ---
 title: Trigger Event by Slug
-api: post /api/v2/public/event/{slug}
+api: post /api/v2/public/event/:slug
 description: Fire a custom event, specifying the app slug in the URL path.
 ---
 

--- a/legacy/api-reference/events/update-event.mdx
+++ b/legacy/api-reference/events/update-event.mdx
@@ -1,6 +1,6 @@
 ---
 title: Update Event
-api: put /api/v2/public/application/event/{event_id}
+api: put /api/v2/public/application/event/:event_id
 description: Update a custom event on your org's default app.
 ---
 

--- a/legacy/api-reference/executions/get-execution.mdx
+++ b/legacy/api-reference/executions/get-execution.mdx
@@ -1,6 +1,6 @@
 ---
 title: Get Execution by ID
-api: get /api/v2/public/execution/{execution_id}
+api: get /api/v2/public/execution/:execution_id
 description: Get a single workflow execution with its node-level detail.
 ---
 

--- a/legacy/api-reference/executions/list-batches.mdx
+++ b/legacy/api-reference/executions/list-batches.mdx
@@ -1,6 +1,6 @@
 ---
 title: List Node Batches
-api: get /api/v2/public/execution/{execution_id}/nodes/{node_id}/batches
+api: get /api/v2/public/execution/:execution_id/nodes/:node_id/batches
 description: List the batches processed by a node in an execution.
 ---
 

--- a/legacy/api-reference/executions/stop-execution.mdx
+++ b/legacy/api-reference/executions/stop-execution.mdx
@@ -1,6 +1,6 @@
 ---
 title: Stop Execution
-api: post /api/v2/public/execution/{instanceId}/stop
+api: post /api/v2/public/execution/:instanceId/stop
 description: Stop a running workflow execution.
 ---
 

--- a/legacy/api-reference/human-tasks/get-human-task.mdx
+++ b/legacy/api-reference/human-tasks/get-human-task.mdx
@@ -1,6 +1,6 @@
 ---
 title: Get Human Task
-api: get /api/v2/public/human-tasks/{id}
+api: get /api/v2/public/human-tasks/:id
 description: Get a public human task (form) by ID.
 ---
 

--- a/legacy/api-reference/human-tasks/submit-human-task.mdx
+++ b/legacy/api-reference/human-tasks/submit-human-task.mdx
@@ -1,6 +1,6 @@
 ---
 title: Submit Human Task
-api: post /api/v2/public/human-tasks/{id}
+api: post /api/v2/public/human-tasks/:id
 description: Submit a public human task (form) response.
 ---
 

--- a/legacy/api-reference/linked-accounts/delete-integration.mdx
+++ b/legacy/api-reference/linked-accounts/delete-integration.mdx
@@ -1,6 +1,6 @@
 ---
 title: Delete an Integration
-api: delete /api/v2/public/linked-account/integration/{slug}
+api: delete /api/v2/public/linked-account/integration/:slug
 description: Remove an integration (or a single connection) from a linked account.
 ---
 

--- a/legacy/api-reference/linked-accounts/delete-linked-account.mdx
+++ b/legacy/api-reference/linked-accounts/delete-linked-account.mdx
@@ -1,6 +1,6 @@
 ---
 title: Delete Linked Account
-api: delete /api/v2/public/linked-account/{linked_account_id}
+api: delete /api/v2/public/linked-account/:linked_account_id
 description: Permanently delete a linked account and all associated data.
 ---
 

--- a/legacy/api-reference/linked-accounts/get-linked-account.mdx
+++ b/legacy/api-reference/linked-accounts/get-linked-account.mdx
@@ -1,6 +1,6 @@
 ---
 title: Get Linked Account
-api: get /api/v2/public/linked-account/{linked_account_id}
+api: get /api/v2/public/linked-account/:linked_account_id
 description: Retrieve details of a specific linked account by its ID.
 ---
 

--- a/legacy/api-reference/mcp-servers/delete-mcp-server.mdx
+++ b/legacy/api-reference/mcp-servers/delete-mcp-server.mdx
@@ -1,6 +1,6 @@
 ---
 title: Delete MCP Server
-api: delete /api/v2/public/mcp-servers/{mcp_server_id}
+api: delete /api/v2/public/mcp-servers/:mcp_server_id
 description: Delete an MCP server.
 ---
 

--- a/legacy/api-reference/mcp-servers/get-mcp-server.mdx
+++ b/legacy/api-reference/mcp-servers/get-mcp-server.mdx
@@ -1,6 +1,6 @@
 ---
 title: Get MCP Server
-api: get /api/v2/public/mcp-servers/{mcp_server_id}
+api: get /api/v2/public/mcp-servers/:mcp_server_id
 description: Get the full configuration of an MCP server.
 ---
 

--- a/legacy/api-reference/mcp-servers/update-mcp-server.mdx
+++ b/legacy/api-reference/mcp-servers/update-mcp-server.mdx
@@ -1,6 +1,6 @@
 ---
 title: Update MCP Server
-api: put /api/v2/public/mcp-servers/{mcp_server_id}
+api: put /api/v2/public/mcp-servers/:mcp_server_id
 description: Update an MCP server's configuration.
 ---
 

--- a/legacy/api-reference/persistent-tables/add-columns.mdx
+++ b/legacy/api-reference/persistent-tables/add-columns.mdx
@@ -1,6 +1,6 @@
 ---
 title: Add Columns
-api: patch /api/v2/public/tables/{table_id}/columns/add
+api: patch /api/v2/public/tables/:table_id/columns/add
 description: Add columns to a persistent table.
 ---
 

--- a/legacy/api-reference/persistent-tables/add-records.mdx
+++ b/legacy/api-reference/persistent-tables/add-records.mdx
@@ -1,6 +1,6 @@
 ---
 title: Add Records
-api: patch /api/v2/public/tables/{table_id}
+api: patch /api/v2/public/tables/:table_id
 description: Add records to a persistent table.
 ---
 

--- a/legacy/api-reference/persistent-tables/delete-record.mdx
+++ b/legacy/api-reference/persistent-tables/delete-record.mdx
@@ -1,6 +1,6 @@
 ---
 title: Delete Record
-api: delete /api/v2/public/tables/{table_id}/{record_id}
+api: delete /api/v2/public/tables/:table_id/:record_id
 description: Delete a single record from a persistent table.
 ---
 

--- a/legacy/api-reference/persistent-tables/delete-table.mdx
+++ b/legacy/api-reference/persistent-tables/delete-table.mdx
@@ -1,6 +1,6 @@
 ---
 title: Delete Table
-api: delete /api/v2/public/tables/{table_id}
+api: delete /api/v2/public/tables/:table_id
 description: Soft-delete a persistent table.
 ---
 

--- a/legacy/api-reference/persistent-tables/get-records.mdx
+++ b/legacy/api-reference/persistent-tables/get-records.mdx
@@ -1,6 +1,6 @@
 ---
 title: Get Table Records
-api: get /api/v2/public/tables/{table_id}
+api: get /api/v2/public/tables/:table_id
 description: Get records from a persistent table.
 ---
 

--- a/legacy/api-reference/persistent-tables/remove-columns.mdx
+++ b/legacy/api-reference/persistent-tables/remove-columns.mdx
@@ -1,6 +1,6 @@
 ---
 title: Remove Columns
-api: delete /api/v2/public/tables/{table_id}/columns/remove
+api: delete /api/v2/public/tables/:table_id/columns/remove
 description: Remove columns from a persistent table.
 ---
 

--- a/legacy/api-reference/persistent-tables/rename-columns.mdx
+++ b/legacy/api-reference/persistent-tables/rename-columns.mdx
@@ -1,6 +1,6 @@
 ---
 title: Rename Columns
-api: patch /api/v2/public/tables/{table_id}/columns/rename
+api: patch /api/v2/public/tables/:table_id/columns/rename
 description: Rename columns in a persistent table.
 ---
 

--- a/legacy/api-reference/persistent-tables/search-records.mdx
+++ b/legacy/api-reference/persistent-tables/search-records.mdx
@@ -1,6 +1,6 @@
 ---
 title: Search Table Records
-api: post /api/v2/public/tables/{table_id}/search
+api: post /api/v2/public/tables/:table_id/search
 description: Search records in a persistent table.
 ---
 

--- a/legacy/api-reference/schedule/delete-schedule.mdx
+++ b/legacy/api-reference/schedule/delete-schedule.mdx
@@ -1,6 +1,6 @@
 ---
 title: Delete Schedule
-api: delete /api/v1/workflow/public/scheduled/{schedule_id}
+api: delete /api/v1/workflow/public/scheduled/:schedule_id
 description: Delete a scheduled trigger.
 ---
 

--- a/legacy/api-reference/schedule/pause-schedule.mdx
+++ b/legacy/api-reference/schedule/pause-schedule.mdx
@@ -1,6 +1,6 @@
 ---
 title: Pause Schedule
-api: put /api/v1/workflow/public/scheduled/{schedule_id}/pause
+api: put /api/v1/workflow/public/scheduled/:schedule_id/pause
 description: Pause a scheduled trigger.
 ---
 

--- a/legacy/api-reference/schedule/resume-schedule.mdx
+++ b/legacy/api-reference/schedule/resume-schedule.mdx
@@ -1,6 +1,6 @@
 ---
 title: Resume Schedule
-api: put /api/v1/workflow/public/scheduled/{schedule_id}/resume
+api: put /api/v1/workflow/public/scheduled/:schedule_id/resume
 description: Resume a paused scheduled trigger.
 ---
 

--- a/legacy/api-reference/schedule/update-schedule.mdx
+++ b/legacy/api-reference/schedule/update-schedule.mdx
@@ -1,6 +1,6 @@
 ---
 title: Update Schedule
-api: put /api/v1/workflow/public/scheduled/{schedule_id}
+api: put /api/v1/workflow/public/scheduled/:schedule_id
 description: Update a scheduled trigger's cron or interval configuration.
 ---
 

--- a/legacy/api-reference/webhooks/delete-webhook.mdx
+++ b/legacy/api-reference/webhooks/delete-webhook.mdx
@@ -1,6 +1,6 @@
 ---
 title: Delete Webhook
-api: delete /api/v2/public/webhook/{id}
+api: delete /api/v2/public/webhook/:id
 description: Delete a webhook subscription.
 ---
 

--- a/legacy/api-reference/webhooks/get-webhook-by-id.mdx
+++ b/legacy/api-reference/webhooks/get-webhook-by-id.mdx
@@ -1,6 +1,6 @@
 ---
 title: Get Webhook by ID
-api: get /api/v2/public/webhook/{id}
+api: get /api/v2/public/webhook/:id
 description: Retrieve a single webhook by its ID.
 ---
 

--- a/legacy/api-reference/webhooks/update-webhook.mdx
+++ b/legacy/api-reference/webhooks/update-webhook.mdx
@@ -1,6 +1,6 @@
 ---
 title: Update Webhook
-api: put /api/v2/public/webhook/{id}
+api: put /api/v2/public/webhook/:id
 description: Update an existing webhook's configuration.
 ---
 

--- a/legacy/api-reference/workflows/delete-workflow.mdx
+++ b/legacy/api-reference/workflows/delete-workflow.mdx
@@ -1,6 +1,6 @@
 ---
 title: Delete Workflow
-api: delete /api/v2/public/workflow/{workflow_id}
+api: delete /api/v2/public/workflow/:workflow_id
 description: Delete a private workflow and its drafts, versions, and triggers.
 ---
 

--- a/legacy/api-reference/workflows/execute-workflow.mdx
+++ b/legacy/api-reference/workflows/execute-workflow.mdx
@@ -1,6 +1,6 @@
 ---
 title: Execute Workflow
-api: post /api/v2/public/workflow/{workflow_id}/execute
+api: post /api/v2/public/workflow/:workflow_id/execute
 description: Execute a published workflow for a linked account.
 ---
 

--- a/legacy/api-reference/workflows/get-draft.mdx
+++ b/legacy/api-reference/workflows/get-draft.mdx
@@ -1,6 +1,6 @@
 ---
 title: Get Workflow Draft
-api: get /api/v2/public/workflow/{workflow_id}/edit
+api: get /api/v2/public/workflow/:workflow_id/edit
 description: Get the editable draft of a workflow.
 ---
 

--- a/legacy/api-reference/workflows/get-workflow.mdx
+++ b/legacy/api-reference/workflows/get-workflow.mdx
@@ -1,6 +1,6 @@
 ---
 title: Get Workflow
-api: get /api/v2/public/workflow/{workflow_id}
+api: get /api/v2/public/workflow/:workflow_id
 description: Get a workflow by ID, including its nodes and edges.
 ---
 

--- a/legacy/api-reference/workflows/publish-workflow.mdx
+++ b/legacy/api-reference/workflows/publish-workflow.mdx
@@ -1,6 +1,6 @@
 ---
 title: Publish Workflow
-api: put /api/v2/public/workflow/{workflow_id}/publish
+api: put /api/v2/public/workflow/:workflow_id/publish
 description: Publish or unpublish a private workflow.
 ---
 

--- a/legacy/api-reference/workflows/request-structure.mdx
+++ b/legacy/api-reference/workflows/request-structure.mdx
@@ -1,6 +1,6 @@
 ---
 title: Get Workflow Request Structure
-api: get /api/v2/public/workflow/request-structure/{workflow_id}
+api: get /api/v2/public/workflow/request-structure/:workflow_id
 description: Get the request body structure a workflow expects on execute.
 ---
 

--- a/legacy/api-reference/workflows/versions.mdx
+++ b/legacy/api-reference/workflows/versions.mdx
@@ -1,6 +1,6 @@
 ---
 title: List Workflow Versions
-api: get /api/v2/public/workflow/versions/{workflow_id}
+api: get /api/v2/public/workflow/versions/:workflow_id
 description: List the published version snapshots of a workflow.
 ---
 

--- a/v3/api-reference/applications/execute-action.mdx
+++ b/v3/api-reference/applications/execute-action.mdx
@@ -1,6 +1,6 @@
 ---
 title: Execute Action
-api: post /api/v2/integration-schema/{slug}/actions/{action_id}/execute
+api: post /api/v2/integration-schema/:slug/actions/:action_id/execute
 description: Execute an application action against a connected account.
 ---
 

--- a/v3/api-reference/applications/get-action-parameters.mdx
+++ b/v3/api-reference/applications/get-action-parameters.mdx
@@ -1,6 +1,6 @@
 ---
 title: Get Action Schema
-api: get /api/v2/integration-schema/{slug}/actions/{action_id}
+api: get /api/v2/integration-schema/:slug/actions/:action_id
 description: Get the parameter schema for an application action.
 ---
 

--- a/v3/api-reference/applications/get-actions.mdx
+++ b/v3/api-reference/applications/get-actions.mdx
@@ -1,6 +1,6 @@
 ---
 title: List Actions
-api: get /api/v2/integration-schema/{slug}/actions
+api: get /api/v2/integration-schema/:slug/actions
 description: List the available actions for a connected application.
 ---
 

--- a/v3/api-reference/applications/get-application.mdx
+++ b/v3/api-reference/applications/get-application.mdx
@@ -1,6 +1,6 @@
 ---
 title: Get Application
-api: get /api/v2/public/application/{slug}
+api: get /api/v2/public/application/:slug
 description: Retrieve details of a specific application by its slug.
 ---
 

--- a/v3/api-reference/auth-structure/get-auth-structure.mdx
+++ b/v3/api-reference/auth-structure/get-auth-structure.mdx
@@ -1,6 +1,6 @@
 ---
 title: Get Auth Structure
-api: get /api/v2/public/auth-structure/{slug}
+api: get /api/v2/public/auth-structure/:slug
 description: Get the authentication field structure for an app.
 ---
 

--- a/v3/api-reference/auth-structure/get-oauth-url.mdx
+++ b/v3/api-reference/auth-structure/get-oauth-url.mdx
@@ -1,6 +1,6 @@
 ---
 title: Get OAuth URL
-api: get /api/v2/public/linked-account/integration/oauth-url/{slug}
+api: get /api/v2/public/linked-account/integration/oauth-url/:slug
 description: Get the OAuth authorization URL for an app.
 ---
 

--- a/v3/api-reference/config-fields/delete-field-value.mdx
+++ b/v3/api-reference/config-fields/delete-field-value.mdx
@@ -1,6 +1,6 @@
 ---
 title: Clear Config Field Value
-api: delete /api/v2/public/config/field/{fieldId}
+api: delete /api/v2/public/config/field/:fieldId
 description: Clear the value of a single config field.
 ---
 

--- a/v3/api-reference/config-fields/get-field-by-id.mdx
+++ b/v3/api-reference/config-fields/get-field-by-id.mdx
@@ -1,6 +1,6 @@
 ---
 title: Get Config Field Options
-api: post /api/v2/public/config/field/{fieldId}
+api: post /api/v2/public/config/field/:fieldId
 description: Resolve the options for a single config field.
 ---
 

--- a/v3/api-reference/config-fields/get-options-for-rule-engine.mdx
+++ b/v3/api-reference/config-fields/get-options-for-rule-engine.mdx
@@ -1,6 +1,6 @@
 ---
 title: Get Rule Engine Options
-api: post /api/v2/public/config/rule-engine/{fieldId}
+api: post /api/v2/public/config/rule-engine/:fieldId
 description: Resolve column options for a rule-engine config field.
 ---
 

--- a/v3/api-reference/config-fields/update-field-value.mdx
+++ b/v3/api-reference/config-fields/update-field-value.mdx
@@ -1,6 +1,6 @@
 ---
 title: Update Config Field Value
-api: put /api/v2/public/config/field/{fieldId}
+api: put /api/v2/public/config/field/:fieldId
 description: Set the value of a single config field.
 ---
 

--- a/v3/api-reference/configs/delete-config-default.mdx
+++ b/v3/api-reference/configs/delete-config-default.mdx
@@ -1,6 +1,6 @@
 ---
 title: Delete Config
-api: delete /api/v2/public/slug/{slug}/config
+api: delete /api/v2/public/slug/:slug/config
 description: Delete the installed config for an app (config ID defaulted).
 ---
 

--- a/v3/api-reference/configs/delete-config.mdx
+++ b/v3/api-reference/configs/delete-config.mdx
@@ -1,6 +1,6 @@
 ---
 title: Delete Config by ID
-api: delete /api/v2/public/slug/{slug}/config/{config_id}
+api: delete /api/v2/public/slug/:slug/config/:config_id
 description: Delete a config installation by config ID.
 ---
 

--- a/v3/api-reference/configs/get-config-default.mdx
+++ b/v3/api-reference/configs/get-config-default.mdx
@@ -1,6 +1,6 @@
 ---
 title: Get Config
-api: get /api/v2/public/slug/{slug}/config
+api: get /api/v2/public/slug/:slug/config
 description: Get the installed config for an app (config ID defaulted).
 ---
 

--- a/v3/api-reference/configs/get-config.mdx
+++ b/v3/api-reference/configs/get-config.mdx
@@ -1,6 +1,6 @@
 ---
 title: Get Config by ID
-api: get /api/v2/public/slug/{slug}/config/{config_id}
+api: get /api/v2/public/slug/:slug/config/:config_id
 description: Get an installed config for an app and config ID.
 ---
 

--- a/v3/api-reference/configs/list-configs.mdx
+++ b/v3/api-reference/configs/list-configs.mdx
@@ -1,6 +1,6 @@
 ---
 title: List Config IDs
-api: get /api/v2/public/slug/{slug}/configs
+api: get /api/v2/public/slug/:slug/configs
 description: List the config IDs installed for an app on a linked account.
 ---
 

--- a/v3/api-reference/configs/toggle-workflow.mdx
+++ b/v3/api-reference/configs/toggle-workflow.mdx
@@ -1,6 +1,6 @@
 ---
 title: Toggle Workflow in Config
-api: patch /api/v2/public/slug/{slug}/config/{config_id}/workflows/{workflow_id}
+api: patch /api/v2/public/slug/:slug/config/:config_id/workflows/:workflow_id
 description: Enable or disable a workflow within a config.
 ---
 

--- a/v3/api-reference/credentials/delete-default-app-credential.mdx
+++ b/v3/api-reference/credentials/delete-default-app-credential.mdx
@@ -1,6 +1,6 @@
 ---
 title: Delete Default-App Credential
-api: delete /api/v2/public/linked-account/default-app/auth-credentials/{key}
+api: delete /api/v2/public/linked-account/default-app/auth-credentials/:key
 description: Remove a single auth credential from the org's default app.
 ---
 

--- a/v3/api-reference/credentials/save-key-credentials.mdx
+++ b/v3/api-reference/credentials/save-key-credentials.mdx
@@ -1,6 +1,6 @@
 ---
 title: Save Key Credentials
-api: put /api/v2/public/linked-account/integration/save-key-credentials/{slug}
+api: put /api/v2/public/linked-account/integration/save-key-credentials/:slug
 description: Save key-based credentials for an app on a linked account.
 ---
 

--- a/v3/api-reference/credentials/upsert-default-app-credential.mdx
+++ b/v3/api-reference/credentials/upsert-default-app-credential.mdx
@@ -1,6 +1,6 @@
 ---
 title: Upsert Default-App Credential
-api: put /api/v2/public/linked-account/default-app/auth-credentials/{key}
+api: put /api/v2/public/linked-account/default-app/auth-credentials/:key
 description: Add or update a single auth credential on the org's default app.
 ---
 

--- a/v3/api-reference/datarefs/clear-records.mdx
+++ b/v3/api-reference/datarefs/clear-records.mdx
@@ -1,6 +1,6 @@
 ---
 title: Clear Dataref Records
-api: put /api/v2/public/dataref/{refName}/clear-records
+api: put /api/v2/public/dataref/:refName/clear-records
 description: Clear all records of a dataref while keeping the dataref.
 ---
 

--- a/v3/api-reference/datarefs/delete-dataref.mdx
+++ b/v3/api-reference/datarefs/delete-dataref.mdx
@@ -1,6 +1,6 @@
 ---
 title: Delete Dataref
-api: delete /api/v2/public/dataref/{refName}
+api: delete /api/v2/public/dataref/:refName
 description: Delete a dataref for a linked account.
 ---
 

--- a/v3/api-reference/datarefs/get-dataref.mdx
+++ b/v3/api-reference/datarefs/get-dataref.mdx
@@ -1,6 +1,6 @@
 ---
 title: Get Dataref
-api: get /api/v2/public/dataref/{refName}
+api: get /api/v2/public/dataref/:refName
 description: Get a dataref's records as a table.
 ---
 

--- a/v3/api-reference/deprecated/list-config-datastores.mdx
+++ b/v3/api-reference/deprecated/list-config-datastores.mdx
@@ -1,6 +1,6 @@
 ---
 title: List Datastores
-api: get /api/v2/public/datastore/config/{slug}
+api: get /api/v2/public/datastore/config/:slug
 description: List the datastore names in an app's config.
 ---
 

--- a/v3/api-reference/deprecated/list-records.mdx
+++ b/v3/api-reference/deprecated/list-records.mdx
@@ -1,6 +1,6 @@
 ---
 title: Get Datastore Records
-api: get /api/v2/public/datastore/config/{slug}/{datastore}/records
+api: get /api/v2/public/datastore/config/:slug/:datastore/records
 description: Get all records from a config datastore.
 ---
 

--- a/v3/api-reference/deprecated/search-records.mdx
+++ b/v3/api-reference/deprecated/search-records.mdx
@@ -1,6 +1,6 @@
 ---
 title: Search Datastore Records
-api: post /api/v2/public/datastore/config/{slug}/{datastore_name}/search
+api: post /api/v2/public/datastore/config/:slug/:datastore_name/search
 description: Search records in a config datastore.
 ---
 

--- a/v3/api-reference/environment-variables/delete-value.mdx
+++ b/v3/api-reference/environment-variables/delete-value.mdx
@@ -1,6 +1,6 @@
 ---
 title: Delete Variable Value
-api: delete /api/v2/public/env/values/{value_id}
+api: delete /api/v2/public/env/values/:value_id
 description: Delete an environment-variable value by ID.
 ---
 

--- a/v3/api-reference/environment-variables/get-definition.mdx
+++ b/v3/api-reference/environment-variables/get-definition.mdx
@@ -1,6 +1,6 @@
 ---
 title: Get Variable Definition
-api: get /api/v2/public/env/definitions/{id}
+api: get /api/v2/public/env/definitions/:id
 description: Get an environment-variable definition by ID.
 ---
 

--- a/v3/api-reference/environment-variables/get-value.mdx
+++ b/v3/api-reference/environment-variables/get-value.mdx
@@ -1,6 +1,6 @@
 ---
 title: Get Variable Value
-api: get /api/v2/public/env/value/{definition_id}
+api: get /api/v2/public/env/value/:definition_id
 description: Resolve a single environment-variable value in its scope.
 ---
 

--- a/v3/api-reference/environment-variables/list-values.mdx
+++ b/v3/api-reference/environment-variables/list-values.mdx
@@ -1,6 +1,6 @@
 ---
 title: List Variable Values
-api: get /api/v2/public/env/values/{scope}
+api: get /api/v2/public/env/values/:scope
 description: List environment-variable values for a scope.
 ---
 

--- a/v3/api-reference/events/delete-event.mdx
+++ b/v3/api-reference/events/delete-event.mdx
@@ -1,6 +1,6 @@
 ---
 title: Delete Event
-api: delete /api/v2/public/application/event/{event_id}
+api: delete /api/v2/public/application/event/:event_id
 description: Remove a custom event from your org's default app.
 ---
 

--- a/v3/api-reference/events/get-event.mdx
+++ b/v3/api-reference/events/get-event.mdx
@@ -1,6 +1,6 @@
 ---
 title: Get Event
-api: get /api/v2/public/application/event/{event_id}
+api: get /api/v2/public/application/event/:event_id
 description: Get a single custom event from your org's default app.
 ---
 

--- a/v3/api-reference/events/trigger-event-by-slug.mdx
+++ b/v3/api-reference/events/trigger-event-by-slug.mdx
@@ -1,6 +1,6 @@
 ---
 title: Trigger Event by Slug
-api: post /api/v2/public/event/{slug}
+api: post /api/v2/public/event/:slug
 description: Fire a custom event, specifying the app slug in the URL path.
 ---
 

--- a/v3/api-reference/events/update-event.mdx
+++ b/v3/api-reference/events/update-event.mdx
@@ -1,6 +1,6 @@
 ---
 title: Update Event
-api: put /api/v2/public/application/event/{event_id}
+api: put /api/v2/public/application/event/:event_id
 description: Update a custom event on your org's default app.
 ---
 

--- a/v3/api-reference/executions/get-execution.mdx
+++ b/v3/api-reference/executions/get-execution.mdx
@@ -1,6 +1,6 @@
 ---
 title: Get Execution by ID
-api: get /api/v2/public/execution/{execution_id}
+api: get /api/v2/public/execution/:execution_id
 description: Get a single workflow execution with its node-level detail.
 ---
 

--- a/v3/api-reference/executions/list-batches.mdx
+++ b/v3/api-reference/executions/list-batches.mdx
@@ -1,6 +1,6 @@
 ---
 title: List Node Batches
-api: get /api/v2/public/execution/{execution_id}/nodes/{node_id}/batches
+api: get /api/v2/public/execution/:execution_id/nodes/:node_id/batches
 description: List the batches processed by a node in an execution.
 ---
 

--- a/v3/api-reference/executions/rerun-execution.mdx
+++ b/v3/api-reference/executions/rerun-execution.mdx
@@ -1,6 +1,6 @@
 ---
 title: Rerun Execution
-api: post /api/v2/public/execution/{instanceId}/rerun
+api: post /api/v2/public/execution/:instanceId/rerun
 description: Retry a failed or stopped workflow execution using its original trigger payload.
 ---
 

--- a/v3/api-reference/executions/stop-execution.mdx
+++ b/v3/api-reference/executions/stop-execution.mdx
@@ -1,6 +1,6 @@
 ---
 title: Stop Execution
-api: post /api/v2/public/execution/{instanceId}/stop
+api: post /api/v2/public/execution/:instanceId/stop
 description: Stop a running workflow execution.
 ---
 

--- a/v3/api-reference/human-tasks/get-human-task.mdx
+++ b/v3/api-reference/human-tasks/get-human-task.mdx
@@ -1,6 +1,6 @@
 ---
 title: Get Human Task
-api: get /api/v2/public/human-tasks/{id}
+api: get /api/v2/public/human-tasks/:id
 description: Get a public human task (form) by ID.
 ---
 

--- a/v3/api-reference/human-tasks/submit-human-task.mdx
+++ b/v3/api-reference/human-tasks/submit-human-task.mdx
@@ -1,6 +1,6 @@
 ---
 title: Submit Human Task
-api: post /api/v2/public/human-tasks/{id}
+api: post /api/v2/public/human-tasks/:id
 description: Submit a public human task (form) response.
 ---
 

--- a/v3/api-reference/linked-accounts/delete-integration.mdx
+++ b/v3/api-reference/linked-accounts/delete-integration.mdx
@@ -1,6 +1,6 @@
 ---
 title: Delete an Integration
-api: delete /api/v2/public/linked-account/integration/{slug}
+api: delete /api/v2/public/linked-account/integration/:slug
 description: Remove an integration (or a single connection) from a linked account.
 ---
 

--- a/v3/api-reference/linked-accounts/delete-linked-account.mdx
+++ b/v3/api-reference/linked-accounts/delete-linked-account.mdx
@@ -1,6 +1,6 @@
 ---
 title: Delete Linked Account
-api: delete /api/v2/public/linked-account/{linked_account_id}
+api: delete /api/v2/public/linked-account/:linked_account_id
 description: Permanently delete a linked account and all associated data.
 ---
 

--- a/v3/api-reference/linked-accounts/get-linked-account.mdx
+++ b/v3/api-reference/linked-accounts/get-linked-account.mdx
@@ -1,6 +1,6 @@
 ---
 title: Get Linked Account
-api: get /api/v2/public/linked-account/{linked_account_id}
+api: get /api/v2/public/linked-account/:linked_account_id
 description: Retrieve details of a specific linked account by its ID.
 ---
 

--- a/v3/api-reference/mcp-servers/delete-mcp-server.mdx
+++ b/v3/api-reference/mcp-servers/delete-mcp-server.mdx
@@ -1,6 +1,6 @@
 ---
 title: Delete MCP Server
-api: delete /api/v2/public/mcp-servers/{mcp_server_id}
+api: delete /api/v2/public/mcp-servers/:mcp_server_id
 description: Delete an MCP server.
 ---
 

--- a/v3/api-reference/mcp-servers/get-mcp-server.mdx
+++ b/v3/api-reference/mcp-servers/get-mcp-server.mdx
@@ -1,6 +1,6 @@
 ---
 title: Get MCP Server
-api: get /api/v2/public/mcp-servers/{mcp_server_id}
+api: get /api/v2/public/mcp-servers/:mcp_server_id
 description: Get the full configuration of an MCP server.
 ---
 

--- a/v3/api-reference/mcp-servers/update-mcp-server.mdx
+++ b/v3/api-reference/mcp-servers/update-mcp-server.mdx
@@ -1,6 +1,6 @@
 ---
 title: Update MCP Server
-api: put /api/v2/public/mcp-servers/{mcp_server_id}
+api: put /api/v2/public/mcp-servers/:mcp_server_id
 description: Update an MCP server's configuration.
 ---
 

--- a/v3/api-reference/persistent-tables/add-columns.mdx
+++ b/v3/api-reference/persistent-tables/add-columns.mdx
@@ -1,6 +1,6 @@
 ---
 title: Add Columns
-api: patch /api/v2/public/tables/{table_id}/columns/add
+api: patch /api/v2/public/tables/:table_id/columns/add
 description: Add columns to a persistent table.
 ---
 

--- a/v3/api-reference/persistent-tables/add-records.mdx
+++ b/v3/api-reference/persistent-tables/add-records.mdx
@@ -1,6 +1,6 @@
 ---
 title: Add Records
-api: patch /api/v2/public/tables/{table_id}
+api: patch /api/v2/public/tables/:table_id
 description: Add records to a persistent table.
 ---
 

--- a/v3/api-reference/persistent-tables/delete-record.mdx
+++ b/v3/api-reference/persistent-tables/delete-record.mdx
@@ -1,6 +1,6 @@
 ---
 title: Delete Record
-api: delete /api/v2/public/tables/{table_id}/{record_id}
+api: delete /api/v2/public/tables/:table_id/:record_id
 description: Delete a single record from a persistent table.
 ---
 

--- a/v3/api-reference/persistent-tables/delete-table.mdx
+++ b/v3/api-reference/persistent-tables/delete-table.mdx
@@ -1,6 +1,6 @@
 ---
 title: Delete Table
-api: delete /api/v2/public/tables/{table_id}
+api: delete /api/v2/public/tables/:table_id
 description: Soft-delete a persistent table.
 ---
 

--- a/v3/api-reference/persistent-tables/get-records.mdx
+++ b/v3/api-reference/persistent-tables/get-records.mdx
@@ -1,6 +1,6 @@
 ---
 title: Get Table Records
-api: get /api/v2/public/tables/{table_id}
+api: get /api/v2/public/tables/:table_id
 description: Get records from a persistent table.
 ---
 

--- a/v3/api-reference/persistent-tables/remove-columns.mdx
+++ b/v3/api-reference/persistent-tables/remove-columns.mdx
@@ -1,6 +1,6 @@
 ---
 title: Remove Columns
-api: delete /api/v2/public/tables/{table_id}/columns/remove
+api: delete /api/v2/public/tables/:table_id/columns/remove
 description: Remove columns from a persistent table.
 ---
 

--- a/v3/api-reference/persistent-tables/rename-columns.mdx
+++ b/v3/api-reference/persistent-tables/rename-columns.mdx
@@ -1,6 +1,6 @@
 ---
 title: Rename Columns
-api: patch /api/v2/public/tables/{table_id}/columns/rename
+api: patch /api/v2/public/tables/:table_id/columns/rename
 description: Rename columns in a persistent table.
 ---
 

--- a/v3/api-reference/persistent-tables/search-records.mdx
+++ b/v3/api-reference/persistent-tables/search-records.mdx
@@ -1,6 +1,6 @@
 ---
 title: Search Table Records
-api: post /api/v2/public/tables/{table_id}/search
+api: post /api/v2/public/tables/:table_id/search
 description: Search records in a persistent table.
 ---
 

--- a/v3/api-reference/schedule/delete-schedule.mdx
+++ b/v3/api-reference/schedule/delete-schedule.mdx
@@ -1,6 +1,6 @@
 ---
 title: Delete Schedule
-api: delete /api/v1/workflow/public/scheduled/{schedule_id}
+api: delete /api/v1/workflow/public/scheduled/:schedule_id
 description: Delete a scheduled trigger.
 ---
 

--- a/v3/api-reference/schedule/pause-schedule.mdx
+++ b/v3/api-reference/schedule/pause-schedule.mdx
@@ -1,6 +1,6 @@
 ---
 title: Pause Schedule
-api: put /api/v1/workflow/public/scheduled/{schedule_id}/pause
+api: put /api/v1/workflow/public/scheduled/:schedule_id/pause
 description: Pause a scheduled trigger.
 ---
 

--- a/v3/api-reference/schedule/resume-schedule.mdx
+++ b/v3/api-reference/schedule/resume-schedule.mdx
@@ -1,6 +1,6 @@
 ---
 title: Resume Schedule
-api: put /api/v1/workflow/public/scheduled/{schedule_id}/resume
+api: put /api/v1/workflow/public/scheduled/:schedule_id/resume
 description: Resume a paused scheduled trigger.
 ---
 

--- a/v3/api-reference/schedule/update-schedule.mdx
+++ b/v3/api-reference/schedule/update-schedule.mdx
@@ -1,6 +1,6 @@
 ---
 title: Update Schedule
-api: put /api/v1/workflow/public/scheduled/{schedule_id}
+api: put /api/v1/workflow/public/scheduled/:schedule_id
 description: Update a scheduled trigger's cron or interval configuration.
 ---
 

--- a/v3/api-reference/webhooks/delete-webhook.mdx
+++ b/v3/api-reference/webhooks/delete-webhook.mdx
@@ -1,6 +1,6 @@
 ---
 title: Delete Webhook
-api: delete /api/v2/public/webhook/{id}
+api: delete /api/v2/public/webhook/:id
 description: Delete a webhook subscription.
 ---
 

--- a/v3/api-reference/webhooks/get-webhook-by-id.mdx
+++ b/v3/api-reference/webhooks/get-webhook-by-id.mdx
@@ -1,6 +1,6 @@
 ---
 title: Get Webhook by ID
-api: get /api/v2/public/webhook/{id}
+api: get /api/v2/public/webhook/:id
 description: Retrieve a single webhook by its ID.
 ---
 

--- a/v3/api-reference/webhooks/update-webhook.mdx
+++ b/v3/api-reference/webhooks/update-webhook.mdx
@@ -1,6 +1,6 @@
 ---
 title: Update Webhook
-api: put /api/v2/public/webhook/{id}
+api: put /api/v2/public/webhook/:id
 description: Update an existing webhook's configuration.
 ---
 

--- a/v3/api-reference/workflows/delete-workflow.mdx
+++ b/v3/api-reference/workflows/delete-workflow.mdx
@@ -1,6 +1,6 @@
 ---
 title: Delete Workflow
-api: delete /api/v2/public/workflow/{workflow_id}
+api: delete /api/v2/public/workflow/:workflow_id
 description: Delete a private workflow and its drafts, versions, and triggers.
 ---
 

--- a/v3/api-reference/workflows/execute-workflow.mdx
+++ b/v3/api-reference/workflows/execute-workflow.mdx
@@ -1,6 +1,6 @@
 ---
 title: Execute Workflow
-api: post /api/v2/public/workflow/{workflow_id}/execute
+api: post /api/v2/public/workflow/:workflow_id/execute
 description: Execute a published workflow for a linked account.
 ---
 

--- a/v3/api-reference/workflows/get-draft.mdx
+++ b/v3/api-reference/workflows/get-draft.mdx
@@ -1,6 +1,6 @@
 ---
 title: Get Workflow Draft
-api: get /api/v2/public/workflow/{workflow_id}/edit
+api: get /api/v2/public/workflow/:workflow_id/edit
 description: Get the editable draft of a workflow.
 ---
 

--- a/v3/api-reference/workflows/get-workflow.mdx
+++ b/v3/api-reference/workflows/get-workflow.mdx
@@ -1,6 +1,6 @@
 ---
 title: Get Workflow
-api: get /api/v2/public/workflow/{workflow_id}
+api: get /api/v2/public/workflow/:workflow_id
 description: Get a workflow by ID, including its nodes and edges.
 ---
 

--- a/v3/api-reference/workflows/publish-workflow.mdx
+++ b/v3/api-reference/workflows/publish-workflow.mdx
@@ -1,6 +1,6 @@
 ---
 title: Publish Workflow
-api: put /api/v2/public/workflow/{workflow_id}/publish
+api: put /api/v2/public/workflow/:workflow_id/publish
 description: Publish or unpublish a private workflow.
 ---
 

--- a/v3/api-reference/workflows/request-structure.mdx
+++ b/v3/api-reference/workflows/request-structure.mdx
@@ -1,6 +1,6 @@
 ---
 title: Get Workflow Request Structure
-api: get /api/v2/public/workflow/request-structure/{workflow_id}
+api: get /api/v2/public/workflow/request-structure/:workflow_id
 description: Get the request body structure a workflow expects on execute.
 ---
 

--- a/v3/api-reference/workflows/versions.mdx
+++ b/v3/api-reference/workflows/versions.mdx
@@ -1,6 +1,6 @@
 ---
 title: List Workflow Versions
-api: get /api/v2/public/workflow/versions/{workflow_id}
+api: get /api/v2/public/workflow/versions/:workflow_id
 description: List the published version snapshots of a workflow.
 ---
 


### PR DESCRIPTION
Reverts gocobalt/mintlify-docs#243

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added API-key authentication details to the API docs, including the required header name and key entry format.

* **Documentation**
  * Standardized many API reference routes to use colon-style path parameters across v2, v3, and legacy docs.
  * Updated several endpoint paths for actions, configs, credentials, datarefs, events, executions, human tasks, linked accounts, MCP servers, persistent tables, schedules, webhooks, and workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->