### PR TITLE
Fix three developer-facing gaps in v3 MCP docs

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -1603,6 +1603,7 @@
                 "pages": [
                   "v3/mcp/get-started/what-is-mcp",
                   "v3/mcp/get-started/getting-started",
+                  "v3/mcp/get-started/programmatic-setup",
                   "v3/mcp/get-started/architecture",
                   "v3/mcp/get-started/choose-your-pattern"
                 ]

--- a/v3/api-reference/javascript-sdk.mdx
+++ b/v3/api-reference/javascript-sdk.mdx
@@ -25,7 +25,7 @@ Before using the JavaScript SDK:
 2. **Generate a Session Token** using the [Node.js SDK](/v3/api-reference/sdks) or [API](/v3/api-reference/session-tokens/generate-session-token)
 
 <Warning>
-Session tokens expire after 24 hours. Generate a new token for each user session.
+Session tokens are valid for 7 days by default. Generate a new token for each user session rather than assuming a fixed lifetime.
 </Warning>
 
 ## Installation
@@ -516,7 +516,7 @@ async function initializeIntegrationPage(sessionToken) {
   <Accordion title="Authentication Errors">
     | Problem | Solution |
     |---------|----------|
-    | "Invalid token" error | Generate a new session token. Tokens expire after 24 hours. |
+    | "Invalid token" error | Generate a new session token. Tokens are valid for 7 days by default. |
     | Token not working after page refresh | Store the token and reinitialize the SDK on page load, or fetch a new token from your backend. |
     | OAuth popup blocked | Ensure `.connect()` is called in response to a user action (click). Browsers block popups not triggered by user interaction. |
   </Accordion>

--- a/v3/api-reference/session-tokens/generate-session-token.mdx
+++ b/v3/api-reference/session-tokens/generate-session-token.mdx
@@ -6,7 +6,7 @@ description: Issue a session token for a linked account.
 
 Issue a JWT session token (and refresh token) for a linked account. Session tokens authenticate hosted and Connect frontends that should never hold your API key — the token itself encodes the org, linked account, and environment.
 
-By default an existing valid token is reused; pass `force_refresh=true` to always mint a new one. Token TTL is determined by service configuration.
+By default an existing valid token is reused; pass `force_refresh=true` to always mint a new one. Token TTL is determined by service configuration and defaults to **7 days (604,800 seconds)** if not overridden for your environment. Always read `expires_in` from the response rather than hard-coding a lifetime.
 
 <ResponseExample>
 ```json 200

--- a/v3/mcp/get-started/getting-started.mdx
+++ b/v3/mcp/get-started/getting-started.mdx
@@ -15,6 +15,10 @@ An MCP server exposes your end users' connected apps as tools an AI agent can ca
 Each linked account gets its own Server URL. Create one linked account per end user before proceeding.
 </Note>
 
+<Tip>
+Setting this up from your backend instead of the dashboard? See [Programmatic setup](/v3/mcp/get-started/programmatic-setup) for the API/SDK path.
+</Tip>
+
 ## Create your MCP server
 
 <Steps>
@@ -213,6 +217,9 @@ If an app returns an auth error, the linked account may not have completed the a
 ## Next steps
 
 <CardGroup cols={2}>
+  <Card title="Programmatic setup" icon="terminal" href="/v3/mcp/get-started/programmatic-setup">
+    Create servers, link accounts, and connect agents from your backend instead of the dashboard.
+  </Card>
   <Card title="Connect from agent code" icon="code" href="/v3/mcp/connect/connect-from-agent-code">
     Wire the Server URL into your agent framework with the Refold SDK.
   </Card>

--- a/v3/mcp/get-started/programmatic-setup.mdx
+++ b/v3/mcp/get-started/programmatic-setup.mdx
@@ -1,0 +1,127 @@
+---
+title: "Programmatic setup"
+description: "Create an MCP server, link an end user, and connect an agent, entirely from code — no dashboard required."
+---
+
+The [Quickstart](/v3/mcp/get-started/getting-started) walks through the Refold dashboard. This page is the code-only path: create an MCP server, register the end user as a linked account, and get a connection your agent SDK can use, without opening the dashboard.
+
+<Info>
+This page describes the **target** programmatic flow. Two pieces of it aren't live yet:
+
+- **The Node.js SDK's package name is unconfirmed.** It ships under the `@refoldai` scope (the browser SDK already does — see [JavaScript SDK](/v3/api-reference/javascript-sdk)), but the exact server-SDK package name is an open decision (Linear DEV-4759). This page uses `@refoldai/refold-node` as a **placeholder** — confirm the real name before you `npm install` it.
+- **There is no single call yet that returns a ready-to-use connection** (Server URL + auth header) for a linked account. That lands with Linear DEV-4901, which defines `refold.mcp.connections.generate()`. Until it ships, get the Server URL from the dashboard's **Overview** tab instead (see [Copy the Server URL](/v3/mcp/get-started/getting-started#create-your-mcp-server)), then skip ahead to [Hand the connection to your agent](#hand-the-connection-to-your-agent).
+
+Steps 1 and 2 below call the REST API directly, so they work today with no SDK dependency.
+</Info>
+
+## Prerequisites
+
+- A Refold account and an **API key** from **Settings > Credentials** (see [Developer app and API keys](/v3/native/configure/developer/developer-app))
+- At least one connector configured with valid credentials (see [Connector setup](/v3/platform/concepts/connector/supported-apps-actions))
+
+## 1. Create or find an MCP server
+
+Create a server with a name and description, or list existing servers to reuse one. Both are live REST endpoints today.
+
+<CodeGroup>
+```bash Create a server
+curl -X POST "https://app.refold.ai/api/v2/public/mcp-servers" \
+  -H "x-api-key: $REFOLD_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{ "name": "Production CRM Server", "description": "Access Salesforce and HubSpot. Create, update, and query contacts, deals, and accounts." }'
+```
+
+```bash List existing servers
+curl -X GET "https://app.refold.ai/api/v2/public/mcp-servers" \
+  -H "x-api-key: $REFOLD_API_KEY" \
+  -H "linked_account_id: YOUR_LINKED_ACCOUNT_ID"
+```
+</CodeGroup>
+
+Creating a server only sets its `name` and `description`. To attach the apps and actions the agent can call, use [Update MCP Server](/v3/api-reference/mcp-servers/update-mcp-server) (the `associated_apps` field) or the dashboard's **Applications** tab — see [Add applications](/v3/mcp/get-started/getting-started#create-your-mcp-server).
+
+<Tip>
+The description is what the agent reads when it connects. Be specific about which apps and actions are available, the same guidance as the [dashboard quickstart](/v3/mcp/get-started/getting-started#create-your-mcp-server).
+</Tip>
+
+See the full [MCP Servers API reference](/v3/api-reference/mcp-servers/list-mcp-servers) for every field.
+
+## 2. Register a linked account
+
+Each end user needs a [linked account](/v3/platform/concepts/linked-account) before they can connect an agent. Create one with your own `account_id` for the end user:
+
+```bash
+curl -X PUT "https://app.refold.ai/api/v2/public/linked-account" \
+  -H "x-api-key: $REFOLD_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{ "account_id": "YOUR_END_USER_ID", "name": "End user display name" }'
+```
+
+See [Upsert Linked Account](/v3/api-reference/linked-accounts/upsert-linked-account) for the full payload.
+
+## 3. Get a connection for the agent
+
+<Warning>
+`refold.mcp.connections.generate()` is not implemented yet (Linear DEV-4901). The snippet below is the target shape. Until it ships, copy the Server URL from the dashboard's **Overview** tab instead, and skip to the next section.
+</Warning>
+
+Once DEV-4901 ships, the Node.js SDK will resolve a server and mint a connection for a linked account in two calls:
+
+```javascript Node.js
+import { Refold } from "@refoldai/refold-node"; // placeholder package name — pending DEV-4759
+
+const refold = new Refold({ apiKey: process.env.REFOLD_API_KEY });
+
+const [server] = await refold.mcp.servers.list({ name: "Production CRM Server" });
+
+const connection = await refold.mcp.connections.generate({
+  serverId: server._id,
+  linkedAccountId: "YOUR_END_USER_ID",
+});
+
+// connection => { url, headers, credential, transport }
+```
+
+`connection` carries everything an agent SDK needs: the full Server URL (`url`), a ready-to-send `Authorization` header (`headers`), the raw token by itself (`credential`), and the transport type (`transport`). See [Connect from agent code](/v3/mcp/connect/connect-from-agent-code) for what each of those maps to per agent framework.
+
+## Hand the connection to your agent
+
+However you obtained it (the SDK call above, once it ships, or copied from the dashboard), the connection is a URL plus an optional auth header. Wire it into your agent SDK the same way for every framework. For example, with the Anthropic Messages API:
+
+```python Python
+import anthropic
+
+client = anthropic.Anthropic()
+
+response = client.beta.messages.create(
+    model="claude-opus-4-7",
+    max_tokens=1024,
+    messages=[{"role": "user", "content": "What tools do you have?"}],
+    mcp_servers=[{
+        "type": "url",
+        "name": "refold",
+        "url": "https://<domain>/mcp/v1/<token>/<server_id>",
+    }],
+    tools=[{"type": "mcp_toolset", "mcp_server_name": "refold"}],
+    betas=["mcp-client-2025-11-20"],
+)
+```
+
+See [Connect from agent code](/v3/mcp/connect/connect-from-agent-code) for the same pattern against the OpenAI Agents SDK, Vercel AI SDK, LangChain, and Mastra, and [Authentication](/v3/mcp/connect/authentication) for how the token maps to a linked account and how to revoke it.
+
+## Next steps
+
+<CardGroup cols={2}>
+  <Card title="Quickstart (dashboard)" icon="browser" href="/v3/mcp/get-started/getting-started">
+    The same flow through the Refold dashboard, if you'd rather click than call the API.
+  </Card>
+  <Card title="Connect from agent code" icon="code" href="/v3/mcp/connect/connect-from-agent-code">
+    Wire a Server URL into every major agent SDK.
+  </Card>
+  <Card title="Authentication" icon="lock" href="/v3/mcp/connect/authentication">
+    How tokens map to linked accounts, scoping, and revocation.
+  </Card>
+  <Card title="MCP Servers API reference" icon="server" href="/v3/api-reference/mcp-servers/list-mcp-servers">
+    Every field on create, list, get, update, and delete.
+  </Card>
+</CardGroup>

--- a/v3/native/configure/developer/server-setup.mdx
+++ b/v3/native/configure/developer/server-setup.mdx
@@ -23,20 +23,20 @@ The SDK targets the base URL `https://app.refold.ai` and sends your API key in t
     Add the Refold Node.js SDK to your backend.
 
     ```bash
-    npm install @cobaltio/cobalt
+    npm install @refoldai/refold-node
     ```
 
     <Note>
-    TODO: confirm the published npm package name and import for the Refold-branded server SDK. The current package on npm is `@cobaltio/cobalt` and the client class is `Cobalt`. Verify whether a renamed Refold package exists before publishing.
+    Package name pending DEV-4759 — confirm before publishing. The Refold npm scope is `@refoldai` (the browser SDK already ships as [`@refoldai/refold-js`](/v3/api-reference/javascript-sdk)), but the exact server-SDK package name is still an open decision. `@refoldai/refold-node` above is a placeholder, not a published package.
     </Note>
   </Step>
   <Step title="Initialize the client">
     Create the client once at startup and read the API key from your environment.
 
     ```javascript Node.js
-    const Cobalt = require("@cobaltio/cobalt");
+    const { Refold } = require("@refoldai/refold-node"); // placeholder package name — pending DEV-4759
 
-    const client = new Cobalt({
+    const client = new Refold({
       apiKey: process.env.REFOLD_API_KEY,
     });
     ```

--- a/v3/native/configure/integration/config-fields.mdx
+++ b/v3/native/configure/integration/config-fields.mdx
@@ -63,7 +63,7 @@ After a customer connects, use the SDK (or the [config APIs](/v3/api-reference/c
 
 <CodeGroup>
 ```javascript SDK
-const config = await cobalt.config({
+const config = await refold.config({
   slug: "hubspot",
   config_id: "config_123", // optional: defaults to the linked account ID
   labels: {},              // optional: dynamic labels for Map v2 fields
@@ -119,7 +119,7 @@ The response lists every field (with its type, options, and current value) and e
 
 <CodeGroup>
 ```javascript SDK
-await cobalt.updateConfig({
+await refold.updateConfig({
   slug: "hubspot",
   config_id: "config_123",
   fields: {
@@ -155,8 +155,8 @@ You can also set a single field's value with the [Update Config Field Value](/v3
 By default a linked account has one config, and its `config_id` is the linked account ID. To run the same workflow against more than one target for the same customer, say a customer syncing to both a **sales** and a **partnerships** HubSpot pipeline, create **additional named configs** by passing your own `config_id`.
 
 ```javascript
-await cobalt.config({ slug: "hubspot", config_id: "pipeline-sales" });
-await cobalt.config({ slug: "hubspot", config_id: "pipeline-partnerships" });
+await refold.config({ slug: "hubspot", config_id: "pipeline-sales" });
+await refold.config({ slug: "hubspot", config_id: "pipeline-partnerships" });
 
 // fire an event against a specific config
 await client.event({

--- a/v3/native/configure/integration/field-types/mapping.mdx
+++ b/v3/native/configure/integration/field-types/mapping.mdx
@@ -71,7 +71,7 @@ The config response lists the field's `options` (the RHS choices) and its `label
 ```
 
 ```javascript Save the mapping
-await cobalt.updateConfig({
+await refold.updateConfig({
   slug: "hubspot",
   config_id: "config_123",
   fields: {

--- a/v3/native/frontend/expose-workflow.mdx
+++ b/v3/native/frontend/expose-workflow.mdx
@@ -66,7 +66,7 @@ To render workflows yourself, read the config, then write the customer's choices
     Call `config()` for the linked account. The `workflows` array tells you what to render.
 
 ```javascript SDK
-const config = await cobalt.config({ slug: "hubspot" });
+const config = await refold.config({ slug: "hubspot" });
 // config.workflows -> [{ id, name, enabled, fields: [...] }, ...]
 ```
   </Step>
@@ -74,7 +74,7 @@ const config = await cobalt.config({ slug: "hubspot" });
     Use `updateConfig()` to enable a workflow and set its workflow-level fields. Reference each field by the `id` from the config response.
 
 ```javascript SDK
-await cobalt.updateConfig({
+await refold.updateConfig({
   slug: "hubspot",
   workflows: [
     {

--- a/v3/native/frontend/react-sdk-flow.mdx
+++ b/v3/native/frontend/react-sdk-flow.mdx
@@ -28,8 +28,12 @@ For a no-code option with no React, use the [Hosted flow](/v3/platform/authentic
     Install the React SDK alongside the underlying JavaScript SDK.
 
 ```bash
-npm install --save @cobaltio/react-cobalt-js @cobaltio/cobalt-js@^8
+npm install --save @cobaltio/react-cobalt-js @refoldai/refold-js
 ```
+
+<Note>
+The underlying JavaScript SDK is `@refoldai/refold-js` (renamed from `@cobaltio/cobalt-js`, see [JavaScript SDK](/v3/api-reference/javascript-sdk)). The React package's own name and rename status are unconfirmed — `@cobaltio/react-cobalt-js` above reflects the current published package.
+</Note>
   </Step>
   <Step title="Wrap your app in the Provider">
     Pass your customer's session token to `<Provider>`. Place it high enough in the tree to cover every component that renders `<Config>`.
@@ -72,7 +76,7 @@ See the [React SDK](/v3/api-reference/sdks) reference for every `<Provider>` and
 </Tip>
 
 <Warning>
-Session tokens expire after 24 hours. Fetch a new token for each customer session and update the `<Provider>`.
+Session tokens are valid for 7 days by default. Fetch a new token for each customer session and update the `<Provider>` rather than assuming a fixed lifetime.
 </Warning>
 
 ## Next steps

--- a/v3/native/ship-and-operate/go-live.mdx
+++ b/v3/native/ship-and-operate/go-live.mdx
@@ -59,7 +59,7 @@ Ship the connection experience inside your product so customers connect without 
     For a fully embedded experience, use the [React SDK flow](/v3/native/frontend/react-sdk-flow) or [build your own](/v3/platform/authentication/connection-flows/build-your-own). The [hosted flow](/v3/platform/authentication/connection-flows/hosted-flow) is fine if a redirect or embedded portal meets your needs.
   </Step>
   <Step title="Mint session tokens on your backend">
-    Generate a [session token](/v3/native/frontend/overview#before-you-start) per customer session on the server so your API key stays server-side. Tokens expire after 24 hours, so mint a fresh one each session.
+    Generate a [session token](/v3/native/frontend/overview#before-you-start) per customer session on the server so your API key stays server-side. Tokens are valid for 7 days by default, so mint a fresh one each session rather than relying on a cached one.
   </Step>
   <Step title="Create a linked account per customer">
     Create a [linked account](/v3/platform/concepts/linked-account) when a customer signs up, and reuse its id in every account-scoped call.

--- a/v3/platform/authentication/connection-flows/build-your-own.mdx
+++ b/v3/platform/authentication/connection-flows/build-your-own.mdx
@@ -25,24 +25,24 @@ For a no-code option, use the [Hosted flow](/v3/platform/authentication/connecti
 
 <Steps>
   <Step title="Install and initialize the SDK">
-    Install `@cobaltio/cobalt-js` and initialize it with the customer's session token.
+    Install `@refoldai/refold-js` and initialize it with the customer's session token.
 
 ```bash
-npm install --save @cobaltio/cobalt-js
+npm install --save @refoldai/refold-js
 ```
 
 ```javascript
-import { Cobalt } from "@cobaltio/cobalt-js";
+import { Refold } from "@refoldai/refold-js";
 
-const cobalt = new Cobalt({ token: "YOUR_SESSION_TOKEN" });
+const refold = new Refold({ token: "YOUR_SESSION_TOKEN" });
 ```
   </Step>
   <Step title="List available apps">
     Use `getApp()` to fetch the apps enabled for the customer and render your own catalog. Pass a slug to fetch a single app, or omit it for all of them.
 
 ```javascript
-const apps = await cobalt.getApp();         // all enabled apps
-const slack = await cobalt.getApp("slack"); // one app
+const apps = await refold.getApp();         // all enabled apps
+const slack = await refold.getApp("slack"); // one app
 ```
 
     <Tip>
@@ -53,14 +53,14 @@ const slack = await cobalt.getApp("slack"); // one app
     Call `connect(slug)` to start the auth flow, OAuth apps open a popup, key-based apps take a credentials payload. Call `disconnect(slug)` to revoke access and delete the app's config for the linked account.
 
 ```javascript
-await cobalt.connect("slack");                  // OAuth: opens popup
-await cobalt.connect("twilio", {                // key-based: saves credentials
+await refold.connect("slack");                  // OAuth: opens popup
+await refold.connect("twilio", {                // key-based: saves credentials
   number: "1234567890",
   sid: "ACCOUNT_SID",
   auth_token: "AUTH_TOKEN",
 });
 
-await cobalt.disconnect("slack");
+await refold.disconnect("slack");
 ```
   </Step>
   <Step title="Render and save config fields">
@@ -75,7 +75,7 @@ See the [JavaScript SDK](/v3/api-reference/javascript-sdk) reference for every m
 </Tip>
 
 <Warning>
-Call `connect()` in response to a user action (a click). Browsers block OAuth popups that aren't triggered by user interaction. Session tokens also expire after 24 hours. Generate a fresh one for each session.
+Call `connect()` in response to a user action (a click). Browsers block OAuth popups that aren't triggered by user interaction. Session tokens are also valid for 7 days by default. Generate a fresh one for each session rather than assuming a fixed lifetime.
 </Warning>
 
 ## Next steps

--- a/v3/platform/authentication/connection-flows/hosted-flow.mdx
+++ b/v3/platform/authentication/connection-flows/hosted-flow.mdx
@@ -38,7 +38,7 @@ If you need the connect experience inside your React app with no redirect, use t
 <Frame>{/* SCREENSHOT: Refold hosted portal listing enabled apps with a connect button → /images/embedded/frontend/hosted-portal.png */}</Frame>
 
 <Warning>
-Session tokens expire after 24 hours. Generate a fresh token (and a fresh connect URL) for each new customer session.
+Session tokens are valid for 7 days by default. Generate a fresh token (and a fresh connect URL) for each new customer session rather than assuming a fixed lifetime.
 </Warning>
 
 ## Next steps

--- a/v3/platform/authentication/managing-connections/connection-status.mdx
+++ b/v3/platform/authentication/managing-connections/connection-status.mdx
@@ -11,16 +11,16 @@ The fields that matter are `connected`, `connected_accounts`, and `reauth_requir
 
 The application object is available on both the client and the server, so you can read status wherever you render your UI:
 
-- **Client-side**: call `cobalt.getApp()` from the [JavaScript SDK](/v3/api-reference/javascript-sdk) (using the customer's session token). Pass a slug for one app, or omit it for every enabled app.
+- **Client-side**: call `refold.getApp()` from the [JavaScript SDK](/v3/api-reference/javascript-sdk) (using the customer's session token). Pass a slug for one app, or omit it for every enabled app.
 - **Server-side**: call the List Applications API or the [Node.js SDK](/v3/api-reference/sdks) with the customer's `linked_account_id`.
 
 <CodeGroup>
 ```javascript JS SDK
 // one app
-const slack = await cobalt.getApp("slack");
+const slack = await refold.getApp("slack");
 
 // every enabled app
-const apps = await cobalt.getApp();
+const apps = await refold.getApp();
 ```
 
 ```bash cURL
@@ -93,7 +93,7 @@ function statusFor(app) {
 
 The application object reflects status at the moment you fetch it. To keep your UI current:
 
-- **Re-fetch after a connect**: call `cobalt.getApp()` again once a customer finishes the flow so the state flips to **Connected**.
+- **Re-fetch after a connect**: call `refold.getApp()` again once a customer finishes the flow so the state flips to **Connected**.
 - **Listen for expiry**: subscribe to the **Connection Expired** webhook to learn the moment a connection breaks, instead of polling. See [Re-authentication](/v3/platform/authentication/managing-connections/re-authentication).
 
 ## Next steps

--- a/v3/platform/authentication/managing-connections/re-authentication.mdx
+++ b/v3/platform/authentication/managing-connections/re-authentication.mdx
@@ -62,17 +62,17 @@ There are two ways to know a connection has expired, use whichever fits your pro
 How the customer reconnects depends on the flow you use:
 
 - **Hosted flow and React SDK flow**: re-auth is handled for you. When a connection has expired, the customer is automatically prompted to reconnect inside the [hosted portal](/v3/platform/authentication/connection-flows/hosted-flow) or the [React connect component](/v3/native/frontend/react-sdk-flow).
-- **Build your own**: when `reauth_required` is `true`, call `cobalt.connect()` with the app slug again, exactly as you did for the first connection. See [Build your own](/v3/platform/authentication/connection-flows/build-your-own).
+- **Build your own**: when `reauth_required` is `true`, call `refold.connect()` with the app slug again, exactly as you did for the first connection. See [Build your own](/v3/platform/authentication/connection-flows/build-your-own).
 
 <CodeGroup>
 ```javascript OAuth app
 // opens the provider's auth screen in a new tab
-cobalt.connect("slack");
+refold.connect("slack");
 ```
 
 ```javascript Key-based app
 // saves fresh credentials for a key-based app
-cobalt.connect("twilio", {
+refold.connect("twilio", {
   number: "<credential>",
   sid: "<credential>",
 });


### PR DESCRIPTION
## Summary

Three developer-facing gaps in the v3 MCP/SDK docs, per request:

**1. Programmatic MCP quickstart** — `v3/mcp/get-started/getting-started.mdx` was dashboard-only. Added `v3/mcp/get-started/programmatic-setup.mdx` (linked from the dashboard quickstart's intro and Next Steps) covering create/find an MCP server → register a linked account → obtain a connection → hand it to an agent, entirely from code.
- Steps 1-2 (create/find server, register linked account) use the **real, existing** REST endpoints (`POST/GET /api/v2/public/mcp-servers`, `PUT /api/v2/public/linked-account`) — verified against the current API reference pages, so these work today.
- Step 3 (`refold.mcp.connections.generate()`, returning `{url, headers, credential, transport}`) is the **target** SDK shape and is explicitly marked as not live yet, pending **DEV-4901**. The page tells the reader to fall back to copying the Server URL from the dashboard until then.

**2. De-Cobalt the SDK surface**
- `v3/native/configure/developer/server-setup.mdx`: replaced the `@cobaltio/cobalt` install + the TODO note with `@refoldai/refold-node` as an explicitly-flagged **placeholder**, with an inline note: "Package name pending DEV-4759 — confirm before publishing."
- Propagated the JavaScript SDK's already-documented rename (`@cobaltio/cobalt-js` → `@refoldai/refold-js`, `Cobalt` class → `Refold`, established in `javascript-sdk.mdx`) to every page that still showed the old package/class/variable names: `build-your-own.mdx`, the JS-SDK half of `react-sdk-flow.mdx`'s install command, `expose-workflow.mdx`, `config-fields.mdx`, `mapping.mdx`, `connection-status.mdx`, `re-authentication.mdx`.
- **Left alone, deliberately**: the React package (`@cobaltio/react-cobalt-js`) — no confirmed rename exists anywhere in the docs (still points at `github.com/gocobalt/react-cobalt-js`, called "not actively maintained" in `sdks.mdx`), so I didn't invent a name for it. Also left alone: the internal rule-engine script-sandbox globals (`cobaltRuleEngine`, `cobaltDataSource` — a different subsystem, not the connect SDK), and non-SDK infra identifiers already flagged as still-migrating in `data-ref-node.mdx` (webhook signature header `x-cobalt-signature`, storage/helm/GitHub URLs, DB names) — these are real infra, not branding text.

**3. Session-token TTL contradiction** — prose said "expire after 24 hours" in 6 places while the API example showed `expires_in: 599747` (~6.9 days). Traced the actual default through `auth-service`:
- `auth-service/src/providers/Locals.ts:169`: `LINKED_ACCOUNT_SESSION_TOKEN_TTL_SECONDS` defaults to **604800** (exactly 7 days) if unset.
- `auth-service/src/services/Auth.ts:92,1603`: this is exactly the field used as `linkedTokenExpirationSeconds` for the session-token endpoint's `expires_in`.
- No override in `.env.example`, so 604800s is the coded default — consistent with the doc's own `599747` example.

Replaced every "24 hours" session-token claim with the verified 7-day default, and added the default + citation to `generate-session-token.mdx`. Left the *unrelated* 24h defaults in `human-task.mdx`, `pdf.mdx`, and `file-handler.mdx` untouched — those are node timeout/TTL settings in a different subsystem, not session tokens.

## Proof artifact

```
$ git diff --stat
 docs.json                                          |   1 +
 v3/api-reference/javascript-sdk.mdx                |   4 +-
 .../session-tokens/generate-session-token.mdx      |   2 +-
 v3/mcp/get-started/getting-started.mdx             |   7 ++
 v3/mcp/get-started/programmatic-setup.mdx          | 127 +++++++++++++++++++++
 v3/native/configure/developer/server-setup.mdx     |   8 +-
 v3/native/configure/integration/config-fields.mdx  |   8 +-
 .../configure/integration/field-types/mapping.mdx  |   2 +-
 v3/native/frontend/expose-workflow.mdx             |   4 +-
 v3/native/frontend/react-sdk-flow.mdx              |   8 +-
 v3/native/ship-and-operate/go-live.mdx             |   2 +-
 .../connection-flows/build-your-own.mdx            |  20 ++--
 .../connection-flows/hosted-flow.mdx               |   2 +-
 .../managing-connections/connection-status.mdx     |   8 +-
 .../managing-connections/re-authentication.mdx     |   6 +-
 15 files changed, 174 insertions(+), 35 deletions(-)
```

```
$ grep -rn "\bcobalt\.\|new Cobalt(\|require(\"@cobaltio/cobalt\"" v3/ --include="*.mdx"
v3/api-reference/javascript-sdk.mdx:61:  - Rename the client: `new Cobalt(...)` becomes `new Refold(...)`
```
(only remaining hit is inside the "Upgrading from" historical explainer, which is correct as-is)

## NEEDS ENG CONFIRMATION

- **Server-SDK package name** (`@refoldai/refold-node` is a placeholder) — pending **DEV-4759** ("move sdk to refold from personal account"). Confirm the real name before anyone copy-pastes `npm install` from `server-setup.mdx`.
- **`refold.mcp.connections.generate()`** doesn't exist yet — pending **DEV-4901**. The programmatic-setup page depends on it for step 3.
- **React package rename status** (`@cobaltio/react-cobalt-js`) — unconfirmed anywhere in the docs; I didn't touch it. Worth a decision on whether it's staying deprecated-as-is or getting its own DEV-4759-style rename.
- **Session-token TTL** — I found and used an authoritative default (604800s / 7 days, from `auth-service/src/providers/Locals.ts:169`), but that's the *coded fallback* when `LINKED_ACCOUNT_SESSION_TOKEN_TTL_SECONDS` is unset. If any production environment overrides this env var to a different value, the docs should be re-confirmed against that.

## Test plan

- [ ] `mintlify dev` locally and click through `v3/mcp/get-started/programmatic-setup.mdx`, `server-setup.mdx`, and the session-token pages to confirm rendering
- [ ] Eng confirms the DEV-4759 package name and DEV-4901 method shape before this ships to customers as final (not placeholder) content

🤖 Generated with [Claude Code](https://claude.com/claude-code)