### PR TITLE
docs(v3): hide unwritten Security & Enterprise Deployment nav pages

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -1569,11 +1569,6 @@
                 "pages": [
                   "v3/security/credentials",
                   "v3/security/compliance",
-                  "v3/security/encryption",
-                  "v3/security/ip-allowlists",
-                  "v3/security/private-connectivity",
-                  "v3/security/data-residency",
-                  "v3/security/data-retention",
                   "v3/security/mcp"
                 ]
               },
@@ -1593,9 +1588,7 @@
                   },
                   "v3/deployment/benchmarking",
                   "v3/deployment/setup-opentelemetry",
-                  "v3/deployment/storage-minio",
-                  "v3/deployment/backup-restore",
-                  "v3/deployment/troubleshooting"
+                  "v3/deployment/backup-restore"
                 ]
               },
               {


### PR DESCRIPTION
## Summary

Removes placeholder/empty pages from the v3 navigation tree so only authored content is reachable. The underlying `.mdx` stub files remain on disk for later authoring — this only changes `docs.json` navigation.

### Pages hidden

**Security & Governance** (placeholder stubs):
- `encryption`
- `ip-allowlists`
- `private-connectivity`
- `data-residency`
- `data-retention`

**Enterprise Deployment** (empty / "content coming soon"):
- `storage-minio`
- `troubleshooting`

### Notes
- Written-out pages that merely used the word "placeholder" in config examples (`docker-compose`, `kubernetes/control-plane`) were left in.
- `docs.json` validated as well-formed JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)