### PR TITLE
Revert "Release notes — v3.7.00"

### DIFF
--- a/changelog/2026.mdx
+++ b/changelog/2026.mdx
@@ -4,42 +4,6 @@ description: "All platform updates, API changes, and integration additions for 2
 rss: true
 ---
 
-<Update label="June 17, 2026" description="v3.7.00 · Universal Connector, MongoDB connector, trigger idempotency & rate limiting">
-
-<Badge color="blue">Platform</Badge> <Badge color="orange">Agent</Badge> <Badge color="purple">Integrations</Badge>
-
-**The Universal Connector goes live end-to-end, a native MongoDB connector ships with 18 actions, trigger idempotency prevents duplicate executions, and per-tenant rate limiting protects your workspace.**
-
-**New Features**
-
-- **Trigger Idempotency**: Opt-in idempotency on triggers prevents duplicate workflow executions when the same event is delivered more than once. Duplicate events are recorded with a new `DUPLICATE` status instead of triggering another run.
-- **Custom Output Field Picker**: The workflow builder Custom Output configuration replaces the free-form text list with a checkbox picker driven by the node's actual test response, with an inline Run Node action, encrypt pills, and preservation of saved fields absent from the latest response.
-- **Connect Portal Field Editing**: Add fields to the Connect Portal faster with a new Add Fields CTA, an empty-state ghost row, and drag-and-drop of dataslot cards from the palette onto the fields list.
-- **Connections Workflow Search**: Search workflows by name and alias across Shared and Private views on the connections page, with a contextual empty state and clear control.
-- **Incremental Sync Ledger**: An account-level sync ledger tab replaces the per-workflow delta cron screen, with workflow, config, and date filters and split workflow/instance columns.
-- **Public Workflow Group Field**: The public workflow list response now includes the workflow's `group` field.
-
-**Improvements**
-
-- **Private Workflows View**: Folder grouping, application icon and name on each item, and a search-aware empty state.
-- **Workflow Settings Consolidation**: Workflow metadata is now shown directly in the settings tab, replacing the separate workflow-details sidebar panel.
-- **MCP Logs Unification**: Global MCP logs and per-server audit logs now use the shared catalog and table layout, with a toolbar aligned to project executions, an export button, and a reusable detail panel.
-- **Custom Output Array Handling**: Custom Output now recurses into arrays of objects with wildcard selectors, hides system envelope fields, and unwraps the test envelope so saved paths match production.
-- **Linked Account Deletion**: Resolved a double URL-encoding issue that could affect linked account deletion.
-- **Terminate Semantics in Loops**: In a loop, `terminate_with_error` now sets the instance to ERRORED and `terminate_with_success` reports the batch as completed without propagating as a terminate — matching pre-revamp behavior across subflow and try-catch contexts.
-- **Try-Catch with Terminate Iteration**: `terminate_iteration` with the success toggle no longer runs the wrapping try-catch's try-success nodes, correctly ending only the iteration.
-- **Transient Integration Retries**: Transient upstream failures (429s, 5xx, connection resets) are now retried at the orchestration layer with each attempt visible in the workflow execution history. Retryable status codes are configurable.
-- **Archive Read Compatibility**: The archive read path auto-detects packed and legacy formats, so previously archived instances remain readable after the storage layout upgrade.
-- **Detailed Authorization Errors**: 403 responses on role-lacking access now include structured detail explaining which permission is missing.
-
-**Integration Updates**
-
-- **MongoDB**: New native MongoDB connector with key-based authentication and 18 actions covering document CRUD (`insert_one`/`insert_many`, `find_one`/`find_many`, `update_one`/`update_many`, `delete_one`/`delete_many`, `replace_one`, `find_one_and_update`, `find_one_and_delete`), aggregation with an automatic 1000-document cap, `count_documents`, `distinct`, `bulk_write`, `list_collections`, `list_databases`, and `ping`.
-- **PostgreSQL**: File validation options — including upload size limits — are now configurable per action.
-- **Dropbox**: Improved `get_user` reliability for Dropbox Business accounts.
-
-</Update>
-
 <Update label="June 15, 2026" description="v3.6.00 · Workday SOAP custom output & Zoho webhook fixes">
 
 <Badge color="orange">Agent</Badge> <Badge color="purple">Integrations</Badge>


### PR DESCRIPTION
Reverts gocobalt/mintlify-docs#256

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed the June 17, 2026 release entry for version 3.7.00 from the changelog.
  * Existing changelog metadata and other release information remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->