### PR TITLE
docs: fix TOC coloring, hide welcome-page TOC, update 2026 changelog

### DIFF
--- a/changelog/2026.mdx
+++ b/changelog/2026.mdx
@@ -4,6 +4,42 @@ description: "All platform updates, API changes, and integration additions for 2
 rss: true
 ---
 
+<Update label="June 17, 2026" description="v3.7.00 · Universal Connector, MongoDB connector, trigger idempotency & rate limiting">
+
+<Badge color="blue">Platform</Badge> <Badge color="orange">Agent</Badge> <Badge color="purple">Integrations</Badge>
+
+**A native MongoDB connector ships with 18 actions, trigger idempotency prevents duplicate executions, and a custom output field picker to output specific result from the execution**
+
+**New Features**
+
+- **Trigger Idempotency**: Opt-in idempotency on triggers prevents duplicate workflow executions when the same event is delivered more than once. Duplicate events are recorded with a new `DUPLICATE` status instead of triggering another run.
+- **Custom Output Field Picker**: The workflow builder Custom Output configuration replaces the free-form text list with a checkbox picker driven by the node's actual test response, with an inline Run Node action, encrypt pills, and preservation of saved fields absent from the latest response.
+- **Connect Portal Field Editing**: Add fields to the Connect Portal faster with a new Add Fields CTA, an empty-state ghost row, and drag-and-drop of dataslot cards from the palette onto the fields list.
+- **Connections Workflow Search**: Search workflows by name and alias across Shared and Private views on the connections page, with a contextual empty state and clear control.
+- **Incremental Sync Ledger**: An account-level sync ledger tab replaces the per-workflow delta cron screen, with workflow, config, and date filters and split workflow/instance columns.
+- **Public Workflow Group Field**: The public workflow list response now includes the workflow's `group` field.
+
+**Improvements**
+
+- **Private Workflows View**: Folder grouping, application icon and name on each item, and a search-aware empty state.
+- **Workflow Settings Consolidation**: Workflow metadata is now shown directly in the settings tab, replacing the separate workflow-details sidebar panel.
+- **MCP Logs Unification**: Global MCP logs and per-server audit logs now use the shared catalog and table layout, with a toolbar aligned to project executions, an export button, and a reusable detail panel.
+- **Custom Output Array Handling**: Custom Output now recurses into arrays of objects with wildcard selectors, hides system envelope fields, and unwraps the test envelope so saved paths match production.
+- **Linked Account Deletion**: Resolved a double URL-encoding issue that could affect linked account deletion.
+- **Terminate Semantics in Loops**: In a loop, `terminate_with_error` now sets the instance to ERRORED and `terminate_with_success` reports the batch as completed without propagating as a terminate — matching pre-revamp behavior across subflow and try-catch contexts.
+- **Try-Catch with Terminate Iteration**: `terminate_iteration` with the success toggle no longer runs the wrapping try-catch's try-success nodes, correctly ending only the iteration.
+- **Transient Integration Retries**: Transient upstream failures (429s, 5xx, connection resets) are now retried at the orchestration layer with each attempt visible in the workflow execution history. Retryable status codes are configurable.
+- **Archive Read Compatibility**: The archive read path auto-detects packed and legacy formats, so previously archived instances remain readable after the storage layout upgrade.
+- **Detailed Authorization Errors**: 403 responses on role-lacking access now include structured detail explaining which permission is missing.
+
+**Integration Updates**
+
+- **MongoDB**: New native MongoDB connector with key-based authentication and 18 actions covering document CRUD (`insert_one`/`insert_many`, `find_one`/`find_many`, `update_one`/`update_many`, `delete_one`/`delete_many`, `replace_one`, `find_one_and_update`, `find_one_and_delete`), aggregation with an automatic 1000-document cap, `count_documents`, `distinct`, `bulk_write`, `list_collections`, `list_databases`, and `ping`.
+- **PostgreSQL**: File validation options — including upload size limits — are now configurable per action.
+- **Dropbox**: Improved `get_user` reliability for Dropbox Business accounts.
+
+</Update>
+
 <Update label="June 15, 2026" description="v3.6.00 · Workday SOAP custom output & Zoho webhook fixes">
 
 <Badge color="orange">Agent</Badge> <Badge color="purple">Integrations</Badge>

--- a/style.css
+++ b/style.css
@@ -238,16 +238,43 @@ button[aria-label*="copy" i],
   letter-spacing: 0.04em;
 }
 
+/* Welcome page: suppress the "On this page" rail without switching the page to
+   `mode: wide`. Wide mode removes the TOC column entirely, which re-centres the
+   content in a wider main area and shifts it right — misaligned with every other
+   page. Keeping default mode preserves the shared layout; visibility:hidden hides
+   the rail while its column keeps reserving space, so content stays aligned.
+   Scoped via the #hide-on-this-page marker element in welcome.mdx. Target the
+   whole #table-of-contents panel (fixed width w-[16.5rem]) so the "On this page"
+   label, active bullet, and list are all hidden while the column keeps its width. */
+body:has(#hide-on-this-page) #table-of-contents {
+  visibility: hidden !important;
+}
+
 /* TOC (right rail) */
+/* Inactive entries must render muted gray. Mintlify's hosted renderer colors
+   changelog <Update> label anchors with the primary color by default (so every
+   date in "On this page" shows blue on the live site); the local CLI does not.
+   Force the muted color explicitly so inactive entries match across versions,
+   in both light and dark modes. The active rule below has higher specificity
+   and keeps the current entry blue. */
 [class*="on-this-page"] a,
 [class*="toc"] a {
   font-family: var(--rf-font-sans);
+  color: var(--rf-base-400) !important;
   border-radius: 0 !important;
+}
+.dark [class*="on-this-page"] a,
+.dark [class*="toc"] a {
+  color: var(--rf-base-300) !important;
 }
 [class*="on-this-page"] a[class*="active"],
 [class*="toc"] a[class*="active"] {
   color: var(--rf-electric-blue) !important;
   font-weight: 600;
+}
+.dark [class*="on-this-page"] a[class*="active"],
+.dark [class*="toc"] a[class*="active"] {
+  color: var(--rf-electric-blue-light) !important;
 }
 
 /* NOTE: the topbar primary CTA (Dashboard) is styled by the robust

--- a/v3/get-started/welcome.mdx
+++ b/v3/get-started/welcome.mdx
@@ -1,8 +1,11 @@
 ---
 title: "Welcome"
 description: "Refold is the AI-native enterprise integration platform. Choose the product that fits how you ship integrations and start building."
-mode: "wide"
 ---
+
+{/* Marker: hides the "On this page" TOC for this page only (see style.css),
+    while keeping the standard page width and left/right spacing. */}
+<div id="hide-on-this-page" style={{ display: "none" }} />
 
 Welcome to **Refold** — the AI-native enterprise integration platform. Refold cuts integration timelines from years to weeks and costs by more than half, built on deep expertise in SAP, Salesforce, Workday, Oracle, and [300+ other applications](/v3/connectors/supported-apps-actions). Every integration ships governed, tested, and production-ready.
 


### PR DESCRIPTION
- style.css: force inactive "On this page" TOC links to muted gray (light/dark) so the hosted renderer stops coloring changelog <Update> date entries blue; keep the active entry electric-blue. Add a scoped rule to hide the #table-of-contents panel on the welcome page.
- welcome.mdx: drop `mode: wide` (which re-centered content and misaligned it) and add a #hide-on-this-page marker so the TOC is hidden via CSS while the page keeps standard left/right spacing.
- changelog/2026.mdx: content update.