### PR TITLE
fix(style): TOC 'On this page' entries all rendering blue in production

### DIFF
--- a/style.css
+++ b/style.css
@@ -251,12 +251,9 @@ body:has(#hide-on-this-page) #table-of-contents {
 }
 
 /* TOC (right rail) */
-/* Inactive entries must render muted gray. Mintlify's hosted renderer colors
-   changelog <Update> label anchors with the primary color by default (so every
-   date in "On this page" shows blue on the live site); the local CLI does not.
-   Force the muted color explicitly so inactive entries match across versions,
-   in both light and dark modes. The active rule below has higher specificity
-   and keeps the current entry blue. */
+/* Inactive entries must render muted gray. In light mode the hosted renderer
+   leaves inactive "On this page" links to inherit the link color (blue), so
+   force the muted color explicitly across light and dark modes. */
 [class*="on-this-page"] a,
 [class*="toc"] a {
   font-family: var(--rf-font-sans);
@@ -267,13 +264,25 @@ body:has(#hide-on-this-page) #table-of-contents {
 .dark [class*="toc"] a {
   color: var(--rf-base-300) !important;
 }
-[class*="on-this-page"] a[class*="active"],
-[class*="toc"] a[class*="active"] {
+/* Active entry. The hosted renderer marks the current item on the parent
+   <li data-active="true">; older/local renderers add an "active" class token on
+   the link itself. Match both.
+   IMPORTANT: use [class~="active"] (whole space-separated token), NEVER
+   [class*="active"] (substring). Hosted anchors carry Tailwind arbitrary-variant
+   classes such as `[li:not([data-active])>&:hover]:text-gray-900` and
+   `[[data-active]>&]:text-primary` whose names literally contain the substring
+   "active", so [class*="active"] matched EVERY entry and painted them all blue. */
+[class*="on-this-page"] a[class~="active"],
+[class*="toc"] a[class~="active"],
+[class*="on-this-page"] li[data-active="true"] > a,
+[class*="toc"] li[data-active="true"] > a {
   color: var(--rf-electric-blue) !important;
   font-weight: 600;
 }
-.dark [class*="on-this-page"] a[class*="active"],
-.dark [class*="toc"] a[class*="active"] {
+.dark [class*="on-this-page"] a[class~="active"],
+.dark [class*="toc"] a[class~="active"],
+.dark [class*="on-this-page"] li[data-active="true"] > a,
+.dark [class*="toc"] li[data-active="true"] > a {
   color: var(--rf-electric-blue-light) !important;
 }
 


### PR DESCRIPTION
## Problem

In production, every "On this page" (TOC) entry rendered electric-blue instead of only the active one — on both v2 and v3, in dark and light mode. It looked correct locally.

## Root cause

The active-entry CSS rule used `a[class*="active"]` — a **substring** match. The hosted Mintlify renderer gives every TOC anchor Tailwind arbitrary-variant classes such as:

- `[li:not([data-active])>&:hover]:text-gray-900`
- `[[data-active]>&]:text-primary`

Those class names literally contain the substring `active`, so `[class*="active"]` matched **every** anchor and applied the active (blue) color to all of them. The local CLI uses different class names, which is why local looked fine.

Confirmed via headless Chrome against `docs.refold.ai`: inactive links computed to `rgb(77,138,255)`.

## Fix

Match the active entry precisely:
- `li[data-active="true"] > a` — how the hosted renderer marks the current item
- `a[class~="active"]` — whole-token match, for local/older renderers

## Verification

Injected the corrected rules into the live `docs.refold.ai` DOM (after removing the old rule) via CDP:
- Active entry → `rgb(77,138,255)` (electric-blue) ✓
- Inactive entries → `rgb(163,163,165)` (`--rf-base-300` gray) ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed “On this page” navigation styling so only the selected entry is highlighted.
  * Improved support for active navigation states in hosted renderers.
  * Ensured inactive entries consistently use muted colors in both light and dark modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->