### PR TITLE
Release notes — v3.8.09 (supersedes v3.8.08)

### DIFF
--- a/changelog/2026.mdx
+++ b/changelog/2026.mdx
@@ -19,10 +19,6 @@ rss: true
 
 - **Logs Export**: The logs export button now triggers reliably.
 
-**API Changes**
-
-- Recovery Queue message responses now include an `ai_analysis.confidence` field (0.0–1.0) on each analysis item.
-
 **Integration Updates**
 
 - **Ramp**: New Ramp connector with OAuth2 (authorization code and client credentials) authentication, dynamic webhook registration, the `transaction.ready_to_sync` inbound trigger, and actions covering transactions, cards, and users.

--- a/changelog/2026.mdx
+++ b/changelog/2026.mdx
@@ -4,6 +4,33 @@ description: "All platform updates, API changes, and integration additions for 2
 rss: true
 ---
 
+<Update label="July 10, 2026" description="v3.8.09 · Recovery Queue confidence, Ramp & Dubber connectors">
+
+<Badge color="blue">Platform</Badge> <Badge color="orange">Agent</Badge> <Badge color="purple">Integrations</Badge>
+
+**Autopilot now analyzes sub-workflow Recovery Queues with an AI confidence score, new Ramp and Dubber connectors ship, and HubSpot HTTP requests handle content types reliably.**
+
+**New Features**
+
+- **Sub-Workflow Recovery Queue Analysis**: Autopilot now descends into sub-workflow instance trees to discover and annotate Recovery Queue records from child failures, including children nested inside loop batches. Notifications are deferred until all sub-workflow children complete so a single, consolidated finding is delivered per parent run.
+- **AI Analysis Confidence Score**: Recovery Queue AI analyses now include a 0.0–1.0 confidence score, surfaced in the record drawer alongside error class and updated-at, with color-coded thresholds (green ≥ 0.80, amber ≥ 0.50, red below). A single analysis can now cover multiple records that share the same failure.
+
+**Improvements**
+
+- **Logs Export**: The logs export button now triggers reliably.
+
+**API Changes**
+
+- Recovery Queue message responses now include an `ai_analysis.confidence` field (0.0–1.0) on each analysis item.
+
+**Integration Updates**
+
+- **Ramp**: New Ramp connector with OAuth2 (authorization code and client credentials) authentication, dynamic webhook registration, the `transaction.ready_to_sync` inbound trigger, and actions covering transactions, cards, and users.
+- **Dubber**: New Dubber connector with OAuth2 and refresh-token support, regional base URL selection, and actions for listing and retrieving recordings including multipart content.
+- **HubSpot**: Improved reliability of HTTP Request node calls to HubSpot V3 endpoints — `Content-Type: application/json` is now applied on POST, PUT, and PATCH requests with a body, while user-configured content types (such as `multipart/form-data`) and GET requests are left untouched.
+
+</Update>
+
 <Update label="July 6, 2026" description="v3.8.07 · Log node parity, Switch node flexibility & trigger reliability">
 
 <Badge color="blue">Platform</Badge> <Badge color="orange">Agent</Badge> <Badge color="purple">Integrations</Badge>


### PR DESCRIPTION
Auto-drafted from the engineering release notes Google Doc by Claude.

**Please review carefully before merging.**

- Verify all customer-facing changes are captured.
- Confirm action-required callouts have correct URLs and instructions.
- Check that no internal context (ticket IDs, customer names, service names, infra metrics) leaked through.
- Confirm doc links resolve.

**Files updated** (July 2026):
- `changelog/2026.mdx`

**This PR supersedes internal-only releases.**

The engineer marked the v3.8.09 tab with `Supersedes: 3.8.08`. Content from those tabs (where found) was consolidated into the v3.8.09 draft, and existing blocks for those versions in the published docs were removed.

| Superseded version | Tab consolidated into draft | Block in published docs |
| --- | --- | --- |
| v3.8.08 | Yes — content included | Not found (never published this period) |

If a superseded block lived in a different period, remove it from that file manually — the drafter only edits the current release period.

⚠️ If the engineer re-runs the drafter, the `v3.8.09` block in this PR will be regenerated and any manual edits to that block will be overwritten. Edits to other blocks in these files are preserved.